### PR TITLE
feat: initial scaffold (core, extension, outlook-addin, openclaw-skill)

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,0 +1,34 @@
+# @defluff/extension
+
+Browser extension (Manifest V3) for Gmail and Outlook Web.
+
+## Development
+
+```bash
+pnpm install          # at the repo root
+pnpm --filter @defluff/extension dev
+```
+
+The `dev` script starts Vite with HMR. Then load the unpacked extension:
+
+1. Open `chrome://extensions`
+2. Enable Developer mode
+3. Click **Load unpacked**, pick `apps/extension/dist`
+4. Open the options page (Details → Extension options) and configure a provider
+
+## Known TODOs before Chrome Web Store submission
+
+- **Icons**: the manifest currently omits `icons`. Add 16/48/128 PNGs in `public/icons/` and reference from `manifest.config.ts`.
+- **Gmail DOM selectors** in `src/content/hosts/gmail.ts` are a best-effort starting point. Validate against live Gmail and update `MESSAGE_SELECTOR` / `BODY_SELECTOR` as Gmail reshuffles its DOM (frequent).
+- **Outlook Web DOM selectors** in `src/content/hosts/outlook.ts` likewise need live validation.
+- **Optional host permissions** for OpenAI-compatible endpoints: the current manifest allows any `http`/`https` under `optional_host_permissions`. Consider prompting the user to grant the specific host instead of leaving it open-ended.
+
+## Architecture
+
+- `src/background.ts` — service worker. Owns all LLM calls. Content scripts message in with `{ type: 'summarize', text }`, SW looks up provider config from `chrome.storage.sync` and delegates to `@defluff/core.summarize()`.
+- `src/content/index.ts` — host dispatcher. Picks the Gmail or Outlook strategy based on `window.location.hostname`.
+- `src/content/hosts/*` — host-specific DOM strategies (where to find email body, where to inject the button).
+- `src/content/ui/*` — Shadow-DOM-hosted button and summary panel. Styles live inside the shadow tree to avoid host-page CSS conflicts.
+- `src/options/*` — React-based settings page for provider + API key.
+
+The extension never calls a FinAegis-operated backend. All provider requests go direct from the service worker to the user's chosen LLM endpoint.

--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -1,0 +1,41 @@
+import { defineManifest } from '@crxjs/vite-plugin';
+
+// Host-scoped permissions only — never `<all_urls>`. The Chrome Web Store will
+// reject an email-scoped extension that asks for access to every page, and
+// users have no reason to grant it.
+const EMAIL_HOSTS = [
+  'https://mail.google.com/*',
+  'https://outlook.office.com/*',
+  'https://outlook.office365.com/*',
+  'https://outlook.live.com/*',
+] as const;
+
+// The service worker fetches LLM provider APIs. These hosts must be in
+// host_permissions so MV3 lets the background script bypass CORS on them.
+// Ollama / custom OpenAI-compatible endpoints will require additional host
+// permissions — either added here for known hosts, or requested via
+// chrome.permissions.request() from the options page (TODO).
+const PROVIDER_HOSTS = [
+  'https://api.anthropic.com/*',
+  'https://api.openai.com/*',
+  'https://generativelanguage.googleapis.com/*',
+] as const;
+
+export default defineManifest({
+  manifest_version: 3,
+  name: 'Defluff',
+  version: '0.0.1',
+  description: 'Strip AI-generated padding from emails. Your keys, your models, no servers.',
+  action: { default_title: 'Defluff' },
+  options_ui: { page: 'src/options/index.html', open_in_tab: true },
+  background: { service_worker: 'src/background.ts', type: 'module' },
+  permissions: ['storage'],
+  host_permissions: [...EMAIL_HOSTS, ...PROVIDER_HOSTS],
+  content_scripts: [
+    {
+      matches: [...EMAIL_HOSTS],
+      js: ['src/content/index.ts'],
+      run_at: 'document_idle',
+    },
+  ],
+});

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@defluff/extension",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Defluff browser extension for Gmail and Outlook Web.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@defluff/core": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@crxjs/vite-plugin": "2.0.0-beta.29",
+    "@types/chrome": "^0.0.287",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,0 +1,39 @@
+import { DefluffError, summarize } from '@defluff/core';
+import type { AppRequest, SummarizeResponse } from './shared/messages.js';
+import { getProviderConfig } from './shared/storage.js';
+
+chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
+  if (!isAppRequest(message)) return undefined;
+
+  if (message.type === 'summarize') {
+    void handleSummarize(message.text).then(sendResponse);
+    return true; // keep channel open for async response
+  }
+
+  return undefined;
+});
+
+async function handleSummarize(text: string): Promise<SummarizeResponse> {
+  const provider = await getProviderConfig();
+  if (!provider) {
+    return {
+      ok: false,
+      error: 'Open the Defluff options page and configure a provider first.',
+      code: 'unknown_provider',
+    };
+  }
+
+  try {
+    const { bullets } = await summarize({ text, provider });
+    return { ok: true, bullets };
+  } catch (err) {
+    if (err instanceof DefluffError) {
+      return { ok: false, error: err.message, code: err.code };
+    }
+    return { ok: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+function isAppRequest(value: unknown): value is AppRequest {
+  return !!value && typeof value === 'object' && 'type' in value;
+}

--- a/apps/extension/src/content/hosts/gmail.ts
+++ b/apps/extension/src/content/hosts/gmail.ts
@@ -1,0 +1,108 @@
+import type { SummarizeResponse } from '../../shared/messages.js';
+import { createButton } from '../ui/button.js';
+import { createPanel } from '../ui/panel.js';
+
+/**
+ * Gmail's DOM uses unstable, obfuscated class names. These selectors are a
+ * best-effort starting point and will need iteration against live Gmail.
+ *
+ * Selectors in use (2025-ish Gmail):
+ *   .ii.gt        — the container wrapping a single expanded message
+ *   .a3s.aiL      — the HTML body of a message
+ *   h2.hP         — the subject heading at the top of the conversation
+ *
+ * When Gmail reshuffles its DOM (common), update these here.
+ */
+const MESSAGE_SELECTOR = '.ii.gt';
+const BODY_SELECTOR = '.a3s.aiL';
+const DEFLUFF_MARKER = 'data-defluff-wired';
+
+export function startGmail(): void {
+  const observer = new MutationObserver(() => scan());
+  observer.observe(document.body, { childList: true, subtree: true });
+  scan();
+}
+
+function scan(): void {
+  const messages = document.querySelectorAll<HTMLElement>(MESSAGE_SELECTOR);
+  messages.forEach((message) => {
+    if (message.hasAttribute(DEFLUFF_MARKER)) return;
+    const body = message.querySelector<HTMLElement>(BODY_SELECTOR);
+    if (!body) return;
+    message.setAttribute(DEFLUFF_MARKER, 'true');
+    wireMessage(message, body);
+  });
+}
+
+function wireMessage(message: HTMLElement, body: HTMLElement): void {
+  let activePanel: { remove: () => void } | null = null;
+
+  const button = createButton(async () => {
+    if (activePanel) return;
+    button.setBusy(true);
+
+    const emailText = extractBodyText(body);
+    let response: SummarizeResponse;
+    try {
+      response = await chrome.runtime.sendMessage({ type: 'summarize', text: emailText });
+    } catch (err) {
+      response = {
+        ok: false,
+        error: err instanceof Error ? err.message : 'Extension error',
+      };
+    }
+
+    button.setBusy(false);
+    activePanel = renderPanel(body, response, () => {
+      activePanel = null;
+    });
+  });
+
+  // Prefer placing the button next to the subject heading if present, else at
+  // the top of the message body. Both are DOM-dependent; Gmail updates this.
+  const subject = document.querySelector<HTMLElement>('h2.hP');
+  if (subject && !subject.querySelector('[data-defluff="button"]')) {
+    subject.style.display = 'flex';
+    subject.style.alignItems = 'center';
+    subject.style.gap = '12px';
+    subject.appendChild(button.element);
+  } else {
+    message.insertBefore(button.element, message.firstChild);
+  }
+}
+
+function extractBodyText(body: HTMLElement): string {
+  // innerText strips HTML but preserves visible text. Good enough for extraction.
+  // innerText reflows on visible text only, which also drops trackers / hidden
+  // prefetch blocks that some senders include.
+  return body.innerText.trim();
+}
+
+function renderPanel(
+  body: HTMLElement,
+  response: SummarizeResponse,
+  onClose: () => void,
+): { remove: () => void } {
+  const originalDisplay = body.style.display;
+  if (response.ok) body.style.display = 'none';
+
+  const panel = createPanel({
+    ...(response.ok ? { bullets: response.bullets } : { error: response.error }),
+    ...(response.ok
+      ? {
+          onShowOriginal: () => {
+            body.style.display = originalDisplay;
+            panel.remove();
+            onClose();
+          },
+        }
+      : {}),
+    onDismiss: () => {
+      body.style.display = originalDisplay;
+      panel.remove();
+      onClose();
+    },
+  });
+  body.parentElement?.insertBefore(panel.element, body);
+  return { remove: () => panel.remove() };
+}

--- a/apps/extension/src/content/hosts/outlook.ts
+++ b/apps/extension/src/content/hosts/outlook.ts
@@ -1,0 +1,85 @@
+import type { SummarizeResponse } from '../../shared/messages.js';
+import { createButton } from '../ui/button.js';
+import { createPanel } from '../ui/panel.js';
+
+/**
+ * Outlook Web uses obfuscated React class names. The most durable hooks are
+ * ARIA roles and aria-labels. These selectors are a best-effort starting point
+ * — iterate against live Outlook when wiring this up. The Outlook desktop
+ * add-in is the preferred path for desktop Outlook users; this script covers
+ * outlook.office.com / outlook.live.com in the browser.
+ */
+const READING_PANE_SELECTOR = '[role="main"] [aria-label*="Message body"]';
+const SUBJECT_SELECTOR = '[role="main"] [id^="subjectLine"], [role="main"] h1, [role="main"] [role="heading"]';
+const DEFLUFF_MARKER = 'data-defluff-wired';
+
+export function startOutlook(): void {
+  const observer = new MutationObserver(() => scan());
+  observer.observe(document.body, { childList: true, subtree: true });
+  scan();
+}
+
+function scan(): void {
+  const body = document.querySelector<HTMLElement>(READING_PANE_SELECTOR);
+  if (!body || body.hasAttribute(DEFLUFF_MARKER)) return;
+  body.setAttribute(DEFLUFF_MARKER, 'true');
+  wireMessage(body);
+}
+
+function wireMessage(body: HTMLElement): void {
+  let activePanel: { remove: () => void } | null = null;
+
+  const button = createButton(async () => {
+    if (activePanel) return;
+    button.setBusy(true);
+
+    const emailText = body.innerText.trim();
+    let response: SummarizeResponse;
+    try {
+      response = await chrome.runtime.sendMessage({ type: 'summarize', text: emailText });
+    } catch (err) {
+      response = {
+        ok: false,
+        error: err instanceof Error ? err.message : 'Extension error',
+      };
+    }
+
+    button.setBusy(false);
+    activePanel = renderPanel(body, response, () => {
+      activePanel = null;
+    });
+  });
+
+  const subject = document.querySelector<HTMLElement>(SUBJECT_SELECTOR);
+  const anchor = subject?.parentElement ?? body;
+  anchor.insertBefore(button.element, anchor.firstChild);
+}
+
+function renderPanel(
+  body: HTMLElement,
+  response: SummarizeResponse,
+  onClose: () => void,
+): { remove: () => void } {
+  const originalDisplay = body.style.display;
+  if (response.ok) body.style.display = 'none';
+
+  const panel = createPanel({
+    ...(response.ok ? { bullets: response.bullets } : { error: response.error }),
+    ...(response.ok
+      ? {
+          onShowOriginal: () => {
+            body.style.display = originalDisplay;
+            panel.remove();
+            onClose();
+          },
+        }
+      : {}),
+    onDismiss: () => {
+      body.style.display = originalDisplay;
+      panel.remove();
+      onClose();
+    },
+  });
+  body.parentElement?.insertBefore(panel.element, body);
+  return { remove: () => panel.remove() };
+}

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -1,0 +1,14 @@
+import { startGmail } from './hosts/gmail.js';
+import { startOutlook } from './hosts/outlook.js';
+
+const host = window.location.hostname;
+
+if (host === 'mail.google.com') {
+  startGmail();
+} else if (
+  host === 'outlook.office.com' ||
+  host === 'outlook.office365.com' ||
+  host === 'outlook.live.com'
+) {
+  startOutlook();
+}

--- a/apps/extension/src/content/ui/button.ts
+++ b/apps/extension/src/content/ui/button.ts
@@ -1,0 +1,55 @@
+import { CONTENT_CSS } from './styles.js';
+
+export interface ButtonController {
+  element: HTMLElement;
+  setBusy(busy: boolean): void;
+  remove(): void;
+}
+
+/**
+ * Create a Shadow-DOM-hosted button. The host element is what you attach to the
+ * page; the shadow tree owns the styles so Gmail/Outlook CSS can't bleed in.
+ */
+export function createButton(onClick: () => void): ButtonController {
+  const host = document.createElement('span');
+  host.dataset.defluff = 'button';
+  host.style.display = 'inline-block';
+
+  const shadow = host.attachShadow({ mode: 'open' });
+  const style = document.createElement('style');
+  style.textContent = CONTENT_CSS;
+  shadow.appendChild(style);
+
+  const button = document.createElement('button');
+  button.className = 'df-button';
+  button.type = 'button';
+
+  const icon = document.createElement('span');
+  icon.className = 'df-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '✦';
+
+  const label = document.createElement('span');
+  label.textContent = 'De-Fluff';
+
+  button.appendChild(icon);
+  button.appendChild(label);
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  });
+  shadow.appendChild(button);
+
+  return {
+    element: host,
+    setBusy(busy) {
+      button.setAttribute('aria-busy', String(busy));
+      button.disabled = busy;
+    },
+    remove() {
+      host.remove();
+    },
+  };
+}

--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -1,0 +1,72 @@
+import { CONTENT_CSS } from './styles.js';
+
+export interface PanelController {
+  element: HTMLElement;
+  remove(): void;
+}
+
+export interface PanelOptions {
+  bullets?: string[];
+  error?: string;
+  onShowOriginal?: () => void;
+  onDismiss?: () => void;
+}
+
+export function createPanel(opts: PanelOptions): PanelController {
+  const host = document.createElement('div');
+  host.dataset.defluff = 'panel';
+
+  const shadow = host.attachShadow({ mode: 'open' });
+  const style = document.createElement('style');
+  style.textContent = CONTENT_CSS;
+  shadow.appendChild(style);
+
+  const panel = document.createElement('div');
+  panel.className = opts.error ? 'df-panel df-error' : 'df-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = opts.error ? 'Defluff error' : 'Defluffed summary';
+  panel.appendChild(heading);
+
+  if (opts.error) {
+    const p = document.createElement('p');
+    p.textContent = opts.error;
+    panel.appendChild(p);
+  } else {
+    const list = document.createElement('ul');
+    for (const bullet of opts.bullets ?? []) {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    }
+    panel.appendChild(list);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'df-actions';
+  if (opts.onShowOriginal) {
+    actions.appendChild(makeLink('Show original', opts.onShowOriginal));
+  }
+  if (opts.onDismiss) {
+    actions.appendChild(makeLink('Dismiss', opts.onDismiss));
+  }
+  if (actions.childElementCount > 0) panel.appendChild(actions);
+
+  shadow.appendChild(panel);
+
+  return {
+    element: host,
+    remove() {
+      host.remove();
+    },
+  };
+}
+
+function makeLink(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'df-link';
+  btn.type = 'button';
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
+}

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared CSS for the in-page button and summary panel. Lives inside a Shadow
+ * DOM host so host-page styles (Gmail's own CSS) can't leak in, and vice-versa.
+ */
+export const CONTENT_CSS = `
+:host {
+  all: initial;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.df-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid #dadce0;
+  border-radius: 18px;
+  background: #fff;
+  color: #3c4043;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s ease, box-shadow 0.12s ease;
+}
+.df-button:hover { background: #f8f9fa; box-shadow: 0 1px 2px rgba(60,64,67,.15); }
+.df-button:focus-visible { outline: 2px solid #1a73e8; outline-offset: 2px; }
+.df-button[aria-busy="true"] { opacity: 0.7; cursor: progress; }
+.df-button .df-icon { font-size: 14px; line-height: 1; }
+
+.df-panel {
+  position: relative;
+  margin: 12px 0;
+  padding: 16px 18px;
+  border: 1px solid #dadce0;
+  border-left: 3px solid #1a73e8;
+  border-radius: 6px;
+  background: #f8faff;
+  color: #202124;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: 0 1px 2px rgba(60,64,67,.08);
+}
+.df-panel h3 {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #5f6368;
+}
+.df-panel ul { margin: 0; padding-left: 18px; }
+.df-panel li { margin-bottom: 4px; }
+.df-panel li:last-child { margin-bottom: 0; }
+.df-panel .df-actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+.df-panel .df-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #1a73e8;
+  font-size: 13px;
+  cursor: pointer;
+  font-weight: 500;
+}
+.df-panel .df-link:hover { text-decoration: underline; }
+.df-panel.df-error { border-left-color: #d93025; background: #fef7f7; }
+.df-panel.df-error h3 { color: #d93025; }
+`;

--- a/apps/extension/src/options/App.tsx
+++ b/apps/extension/src/options/App.tsx
@@ -1,0 +1,177 @@
+import { PROVIDER_KINDS, type ProviderConfig, type ProviderKind } from '@defluff/core';
+import { useEffect, useState } from 'react';
+import { clearProviderConfig, getProviderConfig, setProviderConfig } from '../shared/storage.js';
+
+type Status = 'idle' | 'saving' | 'saved' | 'error';
+
+const PROVIDER_LABELS: Record<ProviderKind, string> = {
+  anthropic: 'Anthropic Claude',
+  openai: 'OpenAI',
+  gemini: 'Google Gemini',
+  'openai-compatible': 'OpenAI-compatible (Ollama, LM Studio, custom)',
+};
+
+const DEFAULT_MODELS: Record<ProviderKind, string> = {
+  anthropic: 'claude-haiku-4-5-20251001',
+  openai: 'gpt-4o-mini',
+  gemini: 'gemini-2.5-flash',
+  'openai-compatible': 'llama3',
+};
+
+export function App() {
+  const [kind, setKind] = useState<ProviderKind>('anthropic');
+  const [apiKey, setApiKey] = useState('');
+  const [model, setModel] = useState('');
+  const [baseUrl, setBaseUrl] = useState('http://localhost:11434/v1');
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    void (async () => {
+      const existing = await getProviderConfig();
+      if (!existing) return;
+      setKind(existing.kind);
+      if ('apiKey' in existing) setApiKey(existing.apiKey ?? '');
+      if ('model' in existing && existing.model) setModel(existing.model);
+      if (existing.kind === 'openai-compatible') setBaseUrl(existing.baseUrl);
+    })();
+  }, []);
+
+  const handleSave = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault();
+    setStatus('saving');
+    setError('');
+    try {
+      const config = buildConfig({ kind, apiKey, model, baseUrl });
+      await setProviderConfig(config);
+      setStatus('saved');
+      window.setTimeout(() => setStatus('idle'), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+      setStatus('error');
+    }
+  };
+
+  const handleClear = async (): Promise<void> => {
+    await clearProviderConfig();
+    setApiKey('');
+    setModel('');
+    setStatus('idle');
+  };
+
+  return (
+    <main>
+      <header>
+        <h1>Defluff</h1>
+        <p className="lede">
+          Your emails never touch our servers. Pick a provider, paste your key,
+          and every De-Fluff click goes straight from your browser to them.
+        </p>
+      </header>
+
+      <form onSubmit={handleSave}>
+        <label>
+          Provider
+          <select value={kind} onChange={(e) => setKind(e.target.value as ProviderKind)}>
+            {PROVIDER_KINDS.map((k) => (
+              <option key={k} value={k}>
+                {PROVIDER_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {kind === 'openai-compatible' && (
+          <label>
+            Base URL
+            <input
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="http://localhost:11434/v1"
+              required
+            />
+            <small>Ollama, LM Studio, or any OpenAI-compatible endpoint. No trailing <code>/chat/completions</code>.</small>
+          </label>
+        )}
+
+        <label>
+          API key {kind === 'openai-compatible' && <small>(optional for local Ollama)</small>}
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={kind === 'openai-compatible' ? 'leave blank for local' : 'paste your key'}
+            autoComplete="off"
+            required={kind !== 'openai-compatible'}
+          />
+        </label>
+
+        <label>
+          Model <small>(leave blank to use the default)</small>
+          <input
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder={DEFAULT_MODELS[kind]}
+          />
+        </label>
+
+        <div className="actions">
+          <button type="submit" disabled={status === 'saving'}>
+            {status === 'saving' ? 'Saving…' : 'Save'}
+          </button>
+          <button type="button" className="secondary" onClick={handleClear}>
+            Clear
+          </button>
+          {status === 'saved' && <span className="ok">Saved</span>}
+          {status === 'error' && <span className="err">{error}</span>}
+        </div>
+      </form>
+
+      <footer>
+        <p>
+          API keys are stored in <code>chrome.storage.sync</code> — encrypted at
+          rest, never sent to FinAegis. Pick fast models: Claude Haiku, GPT-4o
+          mini, or Gemini Flash work best for extraction.
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+function buildConfig(input: {
+  kind: ProviderKind;
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+}): ProviderConfig {
+  const trimmedModel = input.model.trim();
+  switch (input.kind) {
+    case 'anthropic':
+      return {
+        kind: 'anthropic',
+        apiKey: input.apiKey.trim(),
+        ...(trimmedModel ? { model: trimmedModel } : {}),
+      };
+    case 'openai':
+      return {
+        kind: 'openai',
+        apiKey: input.apiKey.trim(),
+        ...(trimmedModel ? { model: trimmedModel } : {}),
+      };
+    case 'gemini':
+      return {
+        kind: 'gemini',
+        apiKey: input.apiKey.trim(),
+        ...(trimmedModel ? { model: trimmedModel } : {}),
+      };
+    case 'openai-compatible':
+      return {
+        kind: 'openai-compatible',
+        baseUrl: input.baseUrl.trim(),
+        model: trimmedModel || DEFAULT_MODELS['openai-compatible'],
+        ...(input.apiKey.trim() ? { apiKey: input.apiKey.trim() } : {}),
+      };
+  }
+}

--- a/apps/extension/src/options/App.tsx
+++ b/apps/extension/src/options/App.tsx
@@ -1,22 +1,14 @@
-import { PROVIDER_KINDS, type ProviderConfig, type ProviderKind } from '@defluff/core';
+import {
+  PROVIDER_DEFAULT_MODELS,
+  PROVIDER_KINDS,
+  PROVIDER_LABELS,
+  type ProviderConfig,
+  type ProviderKind,
+} from '@defluff/core';
 import { useEffect, useState } from 'react';
 import { clearProviderConfig, getProviderConfig, setProviderConfig } from '../shared/storage.js';
 
 type Status = 'idle' | 'saving' | 'saved' | 'error';
-
-const PROVIDER_LABELS: Record<ProviderKind, string> = {
-  anthropic: 'Anthropic Claude',
-  openai: 'OpenAI',
-  gemini: 'Google Gemini',
-  'openai-compatible': 'OpenAI-compatible (Ollama, LM Studio, custom)',
-};
-
-const DEFAULT_MODELS: Record<ProviderKind, string> = {
-  anthropic: 'claude-haiku-4-5-20251001',
-  openai: 'gpt-4o-mini',
-  gemini: 'gemini-2.5-flash',
-  'openai-compatible': 'llama3',
-};
 
 export function App() {
   const [kind, setKind] = useState<ProviderKind>('anthropic');
@@ -113,7 +105,7 @@ export function App() {
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder={DEFAULT_MODELS[kind]}
+            placeholder={PROVIDER_DEFAULT_MODELS[kind]}
           />
         </label>
 
@@ -170,7 +162,7 @@ function buildConfig(input: {
       return {
         kind: 'openai-compatible',
         baseUrl: input.baseUrl.trim(),
-        model: trimmedModel || DEFAULT_MODELS['openai-compatible'],
+        model: trimmedModel || PROVIDER_DEFAULT_MODELS['openai-compatible'],
         ...(input.apiKey.trim() ? { apiKey: input.apiKey.trim() } : {}),
       };
   }

--- a/apps/extension/src/options/index.html
+++ b/apps/extension/src/options/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defluff — Settings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/extension/src/options/main.tsx
+++ b/apps/extension/src/options/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App.js';
+import './styles.css';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('Root element missing');
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/extension/src/options/styles.css
+++ b/apps/extension/src/options/styles.css
@@ -1,0 +1,105 @@
+:root {
+  --bg: #ffffff;
+  --fg: #202124;
+  --muted: #5f6368;
+  --border: #dadce0;
+  --accent: #1a73e8;
+  --accent-hover: #1558b0;
+  --ok: #188038;
+  --err: #d93025;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+main {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+}
+
+header h1 {
+  font-size: 28px;
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.lede {
+  color: var(--muted);
+  margin: 0 0 32px;
+}
+
+form { display: flex; flex-direction: column; gap: 18px; }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 500;
+  font-size: 13px;
+}
+
+label small { font-weight: 400; color: var(--muted); }
+
+input, select {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+input:focus, select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
+}
+
+.actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+
+button {
+  padding: 10px 20px;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+}
+button:hover { background: var(--accent-hover); }
+button:disabled { opacity: 0.6; cursor: not-allowed; }
+button.secondary {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+button.secondary:hover { background: #f1f3f4; }
+
+.ok { color: var(--ok); font-weight: 500; }
+.err { color: var(--err); font-weight: 500; }
+
+footer {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+code {
+  background: #f1f3f4;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}

--- a/apps/extension/src/shared/messages.ts
+++ b/apps/extension/src/shared/messages.ts
@@ -1,0 +1,12 @@
+import type { DefluffErrorCode } from '@defluff/core';
+
+export interface SummarizeRequest {
+  type: 'summarize';
+  text: string;
+}
+
+export type AppRequest = SummarizeRequest;
+
+export type SummarizeResponse =
+  | { ok: true; bullets: string[] }
+  | { ok: false; error: string; code?: DefluffErrorCode };

--- a/apps/extension/src/shared/storage.ts
+++ b/apps/extension/src/shared/storage.ts
@@ -1,0 +1,28 @@
+import type { ProviderConfig } from '@defluff/core';
+
+const STORAGE_KEY = 'defluff.provider';
+
+export async function getProviderConfig(): Promise<ProviderConfig | null> {
+  const result = await chrome.storage.sync.get(STORAGE_KEY);
+  const value = result[STORAGE_KEY];
+  return isProviderConfig(value) ? value : null;
+}
+
+export async function setProviderConfig(config: ProviderConfig): Promise<void> {
+  await chrome.storage.sync.set({ [STORAGE_KEY]: config });
+}
+
+export async function clearProviderConfig(): Promise<void> {
+  await chrome.storage.sync.remove(STORAGE_KEY);
+}
+
+function isProviderConfig(value: unknown): value is ProviderConfig {
+  if (!value || typeof value !== 'object') return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return (
+    kind === 'anthropic' ||
+    kind === 'openai' ||
+    kind === 'gemini' ||
+    kind === 'openai-compatible'
+  );
+}

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["chrome", "vite/client"],
+    "paths": {
+      "@defluff/core": ["../../packages/core/src/index.ts"],
+      "@defluff/core/*": ["../../packages/core/src/*"]
+    }
+  },
+  "include": ["src/**/*", "manifest.config.ts", "vite.config.ts"]
+}

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -1,0 +1,17 @@
+import { crx } from '@crxjs/vite-plugin';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import manifest from './manifest.config.js';
+
+export default defineConfig({
+  plugins: [react(), crx({ manifest })],
+  server: {
+    port: 5173,
+    strictPort: true,
+    hmr: { port: 5174 },
+  },
+  build: {
+    target: 'esnext',
+    sourcemap: true,
+  },
+});

--- a/apps/openclaw-skill/README.md
+++ b/apps/openclaw-skill/README.md
@@ -1,0 +1,32 @@
+# @defluff/openclaw-skill
+
+An [Openclaw](https://openclaw.ai) skill that extracts the actual intent of an email into 3–5 bullets, using the same fixed prompt wording as the browser extension and Outlook add-in.
+
+The skill is pure markdown + YAML — no executable code. Openclaw's configured agent follows the instructions in `SKILL.md` using whatever model the user has set up locally.
+
+## Install
+
+From the Openclaw CLI:
+
+```bash
+# copy into your local skills directory
+mkdir -p ~/.openclaw/workspace/skills/defluff
+cp SKILL.md ~/.openclaw/workspace/skills/defluff/
+```
+
+Or publish to ClawHub:
+
+```bash
+# from this directory
+clawhub publish
+```
+
+See the [Openclaw skills docs](https://docs.openclaw.ai/tools/skills) for details on discovery and updates.
+
+## Usage
+
+Once installed, invoke with a chat prompt like:
+
+> /defluff [paste email here]
+
+Or (with `user-invocable: true`, which is set in the frontmatter) as a slash command in Openclaw's chat interface.

--- a/apps/openclaw-skill/SKILL.md
+++ b/apps/openclaw-skill/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: defluff
+description: Extract the real intent of an email as 3-5 bullets. Strips pleasantries, corporate jargon, and AI-generated padding to surface only facts, intent, and action items.
+user-invocable: true
+---
+
+# defluff
+
+Use this skill when the user pastes an email (or points you at one), and wants only what matters — not the fluff.
+
+## What to do
+
+Given an email, you are an **extraction tool**. Analyze the text. Strip away all pleasantries, corporate jargon, and likely AI-generated padding. Output only the core facts, the sender's underlying intent, and any specific action items or questions requested.
+
+Format strictly as a concise, **3–5 bullet point list**. Do not add conversational filler.
+
+## Rules
+
+- Do not summarize what the email "is about" in prose. Bullets only.
+- Do not restate greetings, sign-offs, or "I hope this finds you well" variants.
+- If the email contains a question, make it one of the bullets.
+- If the email requests an action or a deadline, make it one of the bullets.
+- If the email has no real content (only pleasantries), output a single bullet: `- No substantive content; purely social.`
+
+## Examples
+
+**Input:**
+> Hi team, hope everyone is having a great week! Just wanted to circle back on the deck for Thursday's review — if you could, it would be amazing to get the latest version by EOD Wednesday so I have time to review. Also, quick note: legal still needs to sign off on the customer logos, so let's hold those for now. Thanks so much!
+
+**Output:**
+- Send latest deck by EOD Wednesday for Thursday review
+- Hold customer logos pending legal sign-off

--- a/apps/outlook-addin/README.md
+++ b/apps/outlook-addin/README.md
@@ -1,0 +1,38 @@
+# @defluff/outlook-addin
+
+Office Add-in for Outlook (desktop and web). Adds a **De-Fluff** ribbon button on the Message Read surface that opens a task pane with the bulleted summary.
+
+## Development
+
+```bash
+pnpm install                                    # at the repo root
+pnpm --filter @defluff/outlook-addin dev        # starts Vite on https://localhost:3000
+```
+
+`@vitejs/plugin-basic-ssl` generates a self-signed cert automatically. The first time you hit `https://localhost:3000` you'll need to trust the cert in your browser (and for desktop Outlook, the OS cert store).
+
+### Sideloading into Outlook
+
+1. Keep `pnpm dev` running.
+2. In Outlook (web): **Get Add-ins → My add-ins → Add a custom add-in → Add from File** and pick `manifest.xml`.
+3. Open a message. The **De-Fluff** button appears in the ribbon's Home tab.
+
+For desktop Outlook on Windows, install the manifest via **File → Options → Trust Center → Trust Center Settings → Trusted Add-in Catalogs** (shared network path) or use the [Microsoft 365 admin center](https://admin.microsoft.com) for org-wide deployment.
+
+## Known TODOs before AppSource / production
+
+- **Icons**: manifest references `https://localhost:3000/icons/icon-{16,32,64,80,128}.png`. Add them to a `public/icons/` directory (Vite serves `public/` at root) before production.
+- **Stable hosting URL**: replace every `https://localhost:3000` in `manifest.xml` with the production URL.
+- **Replace the Id GUID**: the current one is a dev-only placeholder. Generate a real GUID.
+- **AppSource validation**: Microsoft validates manifests strictly. Run `npx office-addin-manifest validate manifest.xml` before submission.
+- **CORS verification**: test direct calls from the task pane webview to each provider (Anthropic, OpenAI, Gemini). If any provider blocks the add-in origin, fall back to `packages/proxy` (Cloudflare Worker) rather than introducing a FinAegis-operated server.
+
+## Architecture
+
+- `manifest.xml` — Office Add-in manifest, targets the Message Read surface.
+- `src/taskpane/` — the pane UI. Plain TS + HTML + CSS (no React — keeps the bundle minimal).
+- `src/commands/` — function file. Currently unused (the ribbon button opens the task pane); reserved for future ExecuteFunction commands.
+- `src/shared/storage.ts` — `Office.context.roamingSettings` wrapper for storing the user's provider config (per-user, synced across devices by Office).
+- `src/shared/email.ts` — reads the current message body via `Office.context.mailbox.item.body.getAsync(Text)`.
+
+The task pane calls `@defluff/core.summarize()` directly. No backend, no service-worker indirection — the webview hits the user's chosen LLM endpoint.

--- a/apps/outlook-addin/manifest.xml
+++ b/apps/outlook-addin/manifest.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Outlook Add-in manifest for Defluff. Replace the Id GUID before publishing —
+  the current value is a dev-only placeholder. For production, host the task
+  pane and command assets somewhere stable and update every https://localhost
+  reference accordingly.
+-->
+<OfficeApp
+  xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+  xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides"
+  xsi:type="MailApp">
+
+  <Id>00000000-defl-uff0-0000-000000000001</Id>
+  <Version>0.0.1</Version>
+  <ProviderName>FinAegis</ProviderName>
+  <DefaultLocale>en-US</DefaultLocale>
+  <DisplayName DefaultValue="Defluff" />
+  <Description DefaultValue="Strip AI-generated padding from emails. Summarize any message into 3-5 bullets of actual intent." />
+  <IconUrl DefaultValue="https://localhost:3000/icons/icon-64.png" />
+  <HighResolutionIconUrl DefaultValue="https://localhost:3000/icons/icon-128.png" />
+  <SupportUrl DefaultValue="https://github.com/FinAegis/defluff" />
+
+  <AppDomains>
+    <AppDomain>https://localhost:3000</AppDomain>
+  </AppDomains>
+
+  <Hosts>
+    <Host Name="Mailbox" />
+  </Hosts>
+
+  <Requirements>
+    <Sets>
+      <Set Name="Mailbox" MinVersion="1.5" />
+    </Sets>
+  </Requirements>
+
+  <FormSettings>
+    <Form xsi:type="ItemRead">
+      <DesktopSettings>
+        <SourceLocation DefaultValue="https://localhost:3000/src/taskpane/index.html" />
+        <RequestedHeight>450</RequestedHeight>
+      </DesktopSettings>
+    </Form>
+  </FormSettings>
+
+  <Permissions>ReadItem</Permissions>
+
+  <Rule xsi:type="RuleCollection" Mode="Or">
+    <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read" />
+  </Rule>
+
+  <DisableEntityHighlighting>false</DisableEntityHighlighting>
+
+  <VersionOverrides
+    xmlns="http://schemas.microsoft.com/office/mailappversionoverrides"
+    xsi:type="VersionOverridesV1_0">
+    <Requirements>
+      <bt:Sets DefaultMinVersion="1.3">
+        <bt:Set Name="Mailbox" />
+      </bt:Sets>
+    </Requirements>
+    <Hosts>
+      <Host xsi:type="MailHost">
+        <DesktopFormFactor>
+          <FunctionFile resid="functionFile" />
+          <ExtensionPoint xsi:type="MessageReadCommandSurface">
+            <OfficeTab id="TabDefault">
+              <Group id="defluffGroup">
+                <Label resid="groupLabel" />
+                <Control xsi:type="Button" id="defluffButton">
+                  <Label resid="buttonLabel" />
+                  <Supertip>
+                    <Title resid="buttonLabel" />
+                    <Description resid="buttonDesc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="icon16" />
+                    <bt:Image size="32" resid="icon32" />
+                    <bt:Image size="80" resid="icon80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="taskpaneUrl" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+    </Hosts>
+    <Resources>
+      <bt:Images>
+        <bt:Image id="icon16" DefaultValue="https://localhost:3000/icons/icon-16.png" />
+        <bt:Image id="icon32" DefaultValue="https://localhost:3000/icons/icon-32.png" />
+        <bt:Image id="icon80" DefaultValue="https://localhost:3000/icons/icon-80.png" />
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="functionFile" DefaultValue="https://localhost:3000/src/commands/commands.html" />
+        <bt:Url id="taskpaneUrl" DefaultValue="https://localhost:3000/src/taskpane/index.html" />
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="groupLabel" DefaultValue="Defluff" />
+        <bt:String id="buttonLabel" DefaultValue="De-Fluff" />
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="buttonDesc" DefaultValue="Summarize this email into 3-5 bullets of actual intent." />
+      </bt:LongStrings>
+    </Resources>
+  </VersionOverrides>
+</OfficeApp>

--- a/apps/outlook-addin/package.json
+++ b/apps/outlook-addin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@defluff/outlook-addin",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Defluff Office Add-in for Outlook (desktop and web).",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@defluff/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/office-js": "^1.0.460",
+    "@vitejs/plugin-basic-ssl": "^1.2.0",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/outlook-addin/src/commands/commands.html
+++ b/apps/outlook-addin/src/commands/commands.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Defluff commands</title>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+    <script type="module" src="./commands.ts"></script>
+  </head>
+  <body></body>
+</html>

--- a/apps/outlook-addin/src/commands/commands.ts
+++ b/apps/outlook-addin/src/commands/commands.ts
@@ -1,0 +1,9 @@
+/**
+ * Function file for ribbon-invoked commands. The current manifest uses
+ * `ShowTaskpane` which does not require a function-file handler, so this file
+ * exists as a placeholder for future ExecuteFunction-style commands (e.g. a
+ * "De-Fluff inline" ribbon button that never opens the pane).
+ */
+Office.onReady(() => {
+  // Reserved for future ExecuteFunction commands.
+});

--- a/apps/outlook-addin/src/shared/email.ts
+++ b/apps/outlook-addin/src/shared/email.ts
@@ -1,0 +1,20 @@
+/**
+ * Grab the current message's body as plain text via Office.js. Resolves with
+ * the trimmed body; rejects on Office error.
+ */
+export function getCurrentEmailText(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const item = Office.context.mailbox.item;
+    if (!item || !('body' in item) || !item.body) {
+      reject(new Error('No message selected'));
+      return;
+    }
+    item.body.getAsync(Office.CoercionType.Text, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(String(result.value ?? '').trim());
+      } else {
+        reject(new Error(result.error?.message ?? 'Failed to read message body'));
+      }
+    });
+  });
+}

--- a/apps/outlook-addin/src/shared/storage.ts
+++ b/apps/outlook-addin/src/shared/storage.ts
@@ -1,0 +1,58 @@
+import type { ProviderConfig } from '@defluff/core';
+
+const KEY = 'defluff.provider';
+
+/**
+ * Wrap Office.context.roamingSettings. Reads are synchronous; saves are async
+ * via saveAsync(). roamingSettings are per-add-in, per-user, and synced across
+ * the user's devices by Office — equivalent to chrome.storage.sync.
+ */
+export function getProviderConfig(): ProviderConfig | null {
+  const raw = Office.context.roamingSettings.get(KEY);
+  if (typeof raw === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isProviderConfig(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isProviderConfig(raw) ? raw : null;
+}
+
+export async function setProviderConfig(config: ProviderConfig): Promise<void> {
+  Office.context.roamingSettings.set(KEY, JSON.stringify(config));
+  await new Promise<void>((resolvePromise, reject) => {
+    Office.context.roamingSettings.saveAsync((result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolvePromise();
+      } else {
+        reject(new Error(result.error?.message ?? 'Failed to save settings'));
+      }
+    });
+  });
+}
+
+export async function clearProviderConfig(): Promise<void> {
+  Office.context.roamingSettings.remove(KEY);
+  await new Promise<void>((resolvePromise, reject) => {
+    Office.context.roamingSettings.saveAsync((result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolvePromise();
+      } else {
+        reject(new Error(result.error?.message ?? 'Failed to clear settings'));
+      }
+    });
+  });
+}
+
+function isProviderConfig(value: unknown): value is ProviderConfig {
+  if (!value || typeof value !== 'object') return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return (
+    kind === 'anthropic' ||
+    kind === 'openai' ||
+    kind === 'gemini' ||
+    kind === 'openai-compatible'
+  );
+}

--- a/apps/outlook-addin/src/taskpane/index.html
+++ b/apps/outlook-addin/src/taskpane/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defluff</title>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Defluff</h1>
+        <p class="lede" id="status">Loading…</p>
+      </header>
+
+      <section id="config" hidden>
+        <h2>Configure a provider</h2>
+        <p>Defluff calls your chosen LLM directly — no FinAegis server. Your key stays in Office roaming settings.</p>
+
+        <label>
+          Provider
+          <select id="kind">
+            <option value="anthropic">Anthropic Claude</option>
+            <option value="openai">OpenAI</option>
+            <option value="gemini">Google Gemini</option>
+            <option value="openai-compatible">OpenAI-compatible (Ollama, LM Studio, custom)</option>
+          </select>
+        </label>
+
+        <label id="baseurl-field" hidden>
+          Base URL
+          <input id="baseurl" type="url" placeholder="http://localhost:11434/v1" />
+        </label>
+
+        <label>
+          API key
+          <input id="apikey" type="password" autocomplete="off" placeholder="paste your key" />
+        </label>
+
+        <label>
+          Model <small>(optional)</small>
+          <input id="model" type="text" placeholder="default model for the provider" />
+        </label>
+
+        <div class="actions">
+          <button id="save" type="button">Save</button>
+          <button id="clear" type="button" class="secondary">Clear</button>
+          <span id="save-status" class="status-msg"></span>
+        </div>
+      </section>
+
+      <section id="work" hidden>
+        <button id="run" type="button" class="primary">De-Fluff this email</button>
+        <div id="result" class="result" hidden>
+          <h2>Key points</h2>
+          <ul id="bullets"></ul>
+        </div>
+        <div id="error" class="error" hidden></div>
+        <p class="settings-link">
+          <button id="edit-config" type="button" class="link">Change provider…</button>
+        </p>
+      </section>
+    </main>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/outlook-addin/src/taskpane/main.ts
+++ b/apps/outlook-addin/src/taskpane/main.ts
@@ -1,0 +1,210 @@
+import {
+  DefluffError,
+  type ProviderConfig,
+  type ProviderKind,
+  summarize,
+} from '@defluff/core';
+import { getCurrentEmailText } from '../shared/email.js';
+import {
+  clearProviderConfig,
+  getProviderConfig,
+  setProviderConfig,
+} from '../shared/storage.js';
+
+const DEFAULT_MODELS: Record<ProviderKind, string> = {
+  anthropic: 'claude-haiku-4-5-20251001',
+  openai: 'gpt-4o-mini',
+  gemini: 'gemini-2.5-flash',
+  'openai-compatible': 'llama3',
+};
+
+Office.onReady(() => {
+  wireUi();
+  const existing = getProviderConfig();
+  if (existing) {
+    showWork();
+  } else {
+    showConfig();
+  }
+});
+
+function wireUi(): void {
+  byId<HTMLSelectElement>('kind').addEventListener('change', () => {
+    syncProviderFields();
+  });
+
+  byId<HTMLButtonElement>('save').addEventListener('click', () => {
+    void handleSave();
+  });
+
+  byId<HTMLButtonElement>('clear').addEventListener('click', () => {
+    void handleClear();
+  });
+
+  byId<HTMLButtonElement>('run').addEventListener('click', () => {
+    void handleRun();
+  });
+
+  byId<HTMLButtonElement>('edit-config').addEventListener('click', () => {
+    showConfig(getProviderConfig());
+  });
+}
+
+function showConfig(existing: ProviderConfig | null = getProviderConfig()): void {
+  byId('status').textContent = existing
+    ? 'Update your provider below.'
+    : 'Pick a provider and paste your key.';
+  byId('config').hidden = false;
+  byId('work').hidden = true;
+
+  if (existing) {
+    byId<HTMLSelectElement>('kind').value = existing.kind;
+    if ('apiKey' in existing) byId<HTMLInputElement>('apikey').value = existing.apiKey ?? '';
+    if ('model' in existing && existing.model) byId<HTMLInputElement>('model').value = existing.model;
+    if (existing.kind === 'openai-compatible') {
+      byId<HTMLInputElement>('baseurl').value = existing.baseUrl;
+    }
+  }
+  syncProviderFields();
+}
+
+function showWork(): void {
+  byId('status').textContent = 'Ready. Open an email and click De-Fluff.';
+  byId('config').hidden = true;
+  byId('work').hidden = false;
+  byId('result').hidden = true;
+  byId('error').hidden = true;
+}
+
+function syncProviderFields(): void {
+  const kind = byId<HTMLSelectElement>('kind').value as ProviderKind;
+  const baseurlField = byId('baseurl-field');
+  baseurlField.hidden = kind !== 'openai-compatible';
+  const apiKeyInput = byId<HTMLInputElement>('apikey');
+  apiKeyInput.required = kind !== 'openai-compatible';
+  byId<HTMLInputElement>('model').placeholder = DEFAULT_MODELS[kind];
+}
+
+async function handleSave(): Promise<void> {
+  const kind = byId<HTMLSelectElement>('kind').value as ProviderKind;
+  const apiKey = byId<HTMLInputElement>('apikey').value.trim();
+  const model = byId<HTMLInputElement>('model').value.trim();
+  const baseUrl = byId<HTMLInputElement>('baseurl').value.trim();
+
+  try {
+    const config = buildConfig({ kind, apiKey, model, baseUrl });
+    await setProviderConfig(config);
+    setSaveStatus('Saved', 'ok');
+    window.setTimeout(() => showWork(), 600);
+  } catch (err) {
+    setSaveStatus(err instanceof Error ? err.message : 'Failed to save', 'err');
+  }
+}
+
+async function handleClear(): Promise<void> {
+  await clearProviderConfig();
+  byId<HTMLInputElement>('apikey').value = '';
+  byId<HTMLInputElement>('model').value = '';
+  setSaveStatus('Cleared', 'ok');
+}
+
+async function handleRun(): Promise<void> {
+  const config = getProviderConfig();
+  if (!config) {
+    showConfig(null);
+    return;
+  }
+
+  const runButton = byId<HTMLButtonElement>('run');
+  runButton.disabled = true;
+  runButton.textContent = 'Extracting…';
+  byId('result').hidden = true;
+  byId('error').hidden = true;
+
+  try {
+    const text = await getCurrentEmailText();
+    if (!text) throw new DefluffError('bad_request', 'Message body is empty.');
+    const { bullets } = await summarize({ text, provider: config });
+    renderBullets(bullets);
+  } catch (err) {
+    renderError(err);
+  } finally {
+    runButton.disabled = false;
+    runButton.textContent = 'De-Fluff this email';
+  }
+}
+
+function renderBullets(bullets: string[]): void {
+  const list = byId<HTMLUListElement>('bullets');
+  list.replaceChildren();
+  for (const bullet of bullets) {
+    const li = document.createElement('li');
+    li.textContent = bullet;
+    list.appendChild(li);
+  }
+  byId('result').hidden = false;
+}
+
+function renderError(err: unknown): void {
+  const message =
+    err instanceof DefluffError
+      ? `${err.code}: ${err.message}`
+      : err instanceof Error
+        ? err.message
+        : 'Unknown error';
+  const pane = byId('error');
+  pane.textContent = message;
+  pane.hidden = false;
+}
+
+function buildConfig(input: {
+  kind: ProviderKind;
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+}): ProviderConfig {
+  switch (input.kind) {
+    case 'anthropic':
+      return {
+        kind: 'anthropic',
+        apiKey: input.apiKey,
+        ...(input.model ? { model: input.model } : {}),
+      };
+    case 'openai':
+      return {
+        kind: 'openai',
+        apiKey: input.apiKey,
+        ...(input.model ? { model: input.model } : {}),
+      };
+    case 'gemini':
+      return {
+        kind: 'gemini',
+        apiKey: input.apiKey,
+        ...(input.model ? { model: input.model } : {}),
+      };
+    case 'openai-compatible':
+      if (!input.baseUrl) throw new Error('Base URL is required for OpenAI-compatible endpoints.');
+      return {
+        kind: 'openai-compatible',
+        baseUrl: input.baseUrl,
+        model: input.model || DEFAULT_MODELS['openai-compatible'],
+        ...(input.apiKey ? { apiKey: input.apiKey } : {}),
+      };
+  }
+}
+
+function setSaveStatus(text: string, variant: 'ok' | 'err'): void {
+  const el = byId('save-status');
+  el.textContent = text;
+  el.className = `status-msg ${variant}`;
+  window.setTimeout(() => {
+    el.textContent = '';
+    el.className = 'status-msg';
+  }, 2000);
+}
+
+function byId<T extends HTMLElement = HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Missing element: ${id}`);
+  return el as T;
+}

--- a/apps/outlook-addin/src/taskpane/main.ts
+++ b/apps/outlook-addin/src/taskpane/main.ts
@@ -1,5 +1,6 @@
 import {
   DefluffError,
+  PROVIDER_DEFAULT_MODELS,
   type ProviderConfig,
   type ProviderKind,
   summarize,
@@ -10,13 +11,6 @@ import {
   getProviderConfig,
   setProviderConfig,
 } from '../shared/storage.js';
-
-const DEFAULT_MODELS: Record<ProviderKind, string> = {
-  anthropic: 'claude-haiku-4-5-20251001',
-  openai: 'gpt-4o-mini',
-  gemini: 'gemini-2.5-flash',
-  'openai-compatible': 'llama3',
-};
 
 Office.onReady(() => {
   wireUi();
@@ -82,7 +76,7 @@ function syncProviderFields(): void {
   baseurlField.hidden = kind !== 'openai-compatible';
   const apiKeyInput = byId<HTMLInputElement>('apikey');
   apiKeyInput.required = kind !== 'openai-compatible';
-  byId<HTMLInputElement>('model').placeholder = DEFAULT_MODELS[kind];
+  byId<HTMLInputElement>('model').placeholder = PROVIDER_DEFAULT_MODELS[kind];
 }
 
 async function handleSave(): Promise<void> {
@@ -187,7 +181,7 @@ function buildConfig(input: {
       return {
         kind: 'openai-compatible',
         baseUrl: input.baseUrl,
-        model: input.model || DEFAULT_MODELS['openai-compatible'],
+        model: input.model || PROVIDER_DEFAULT_MODELS['openai-compatible'],
         ...(input.apiKey ? { apiKey: input.apiKey } : {}),
       };
   }

--- a/apps/outlook-addin/src/taskpane/styles.css
+++ b/apps/outlook-addin/src/taskpane/styles.css
@@ -1,0 +1,120 @@
+:root {
+  --bg: #ffffff;
+  --fg: #201f1e;
+  --muted: #605e5c;
+  --border: #edebe9;
+  --accent: #0078d4;
+  --accent-hover: #106ebe;
+  --ok: #107c10;
+  --err: #a4262c;
+  --panel: #f3f2f1;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Segoe UI", Tahoma, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+main { padding: 20px; }
+
+header h1 {
+  margin: 0 0 6px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.lede { color: var(--muted); margin: 0 0 20px; }
+
+section { display: flex; flex-direction: column; gap: 14px; }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+label small { font-weight: 400; color: var(--muted); }
+
+input, select {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  font: inherit;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+input:focus, select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
+}
+
+.actions { display: flex; align-items: center; gap: 10px; margin-top: 6px; flex-wrap: wrap; }
+
+button {
+  padding: 8px 16px;
+  border-radius: 2px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+button:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+button:disabled { opacity: 0.6; cursor: not-allowed; }
+button.secondary { background: transparent; color: var(--muted); border-color: var(--border); }
+button.secondary:hover { background: #f3f2f1; color: var(--fg); }
+button.primary { width: 100%; padding: 12px; font-size: 15px; }
+button.link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 500;
+}
+button.link:hover { text-decoration: underline; background: none; color: var(--accent-hover); }
+
+.status-msg { font-weight: 500; font-size: 13px; }
+.status-msg.ok { color: var(--ok); }
+.status-msg.err { color: var(--err); }
+
+.result {
+  margin-top: 8px;
+  padding: 14px 16px;
+  background: var(--panel);
+  border-left: 3px solid var(--accent);
+  border-radius: 2px;
+}
+.result h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.result ul { margin: 0; padding-left: 20px; }
+.result li { margin-bottom: 4px; }
+
+.error {
+  margin-top: 8px;
+  padding: 12px 14px;
+  background: #fde7e9;
+  border-left: 3px solid var(--err);
+  color: var(--err);
+  font-size: 13px;
+  border-radius: 2px;
+}
+
+.settings-link { margin-top: 14px; font-size: 13px; color: var(--muted); }

--- a/apps/outlook-addin/tsconfig.json
+++ b/apps/outlook-addin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["office-js", "vite/client"],
+    "paths": {
+      "@defluff/core": ["../../packages/core/src/index.ts"],
+      "@defluff/core/*": ["../../packages/core/src/*"]
+    }
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/apps/outlook-addin/vite.config.ts
+++ b/apps/outlook-addin/vite.config.ts
@@ -1,0 +1,21 @@
+import basicSsl from '@vitejs/plugin-basic-ssl';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [basicSsl()],
+  server: {
+    port: 3000,
+    strictPort: true,
+  },
+  build: {
+    target: 'esnext',
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        taskpane: resolve(__dirname, 'src/taskpane/index.html'),
+        commands: resolve(__dirname, 'src/commands/commands.html'),
+      },
+    },
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@defluff/core",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared extraction logic, provider adapters, and system prompt for Defluff clients.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./prompt": "./src/prompt.ts",
+    "./providers": "./src/providers/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,40 @@
+export type DefluffErrorCode =
+  | 'network'
+  | 'auth'
+  | 'rate_limit'
+  | 'bad_request'
+  | 'server'
+  | 'aborted'
+  | 'no_bullets'
+  | 'unknown_provider';
+
+export class DefluffError extends Error {
+  override readonly name = 'DefluffError';
+  readonly code: DefluffErrorCode;
+  readonly status: number | undefined;
+  readonly detail: unknown;
+
+  constructor(
+    code: DefluffErrorCode,
+    message: string,
+    options?: { status?: number; detail?: unknown; cause?: unknown },
+  ) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.code = code;
+    this.status = options?.status;
+    this.detail = options?.detail;
+  }
+}
+
+/**
+ * Map an HTTP status to a DefluffErrorCode. Providers differ wildly in their
+ * error shapes, so we normalize on the status + a best-effort message here and
+ * let callers surface a friendly UX.
+ */
+export function codeFromStatus(status: number): DefluffErrorCode {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 429) return 'rate_limit';
+  if (status >= 500) return 'server';
+  if (status >= 400) return 'bad_request';
+  return 'unknown_provider';
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,11 @@ export { DefluffError } from './errors.js';
 export type { DefluffErrorCode } from './errors.js';
 export { parseBullets } from './parse.js';
 export { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
-export { PROVIDER_KINDS } from './providers/index.js';
+export {
+  PROVIDER_DEFAULT_MODELS,
+  PROVIDER_KINDS,
+  PROVIDER_LABELS,
+} from './providers/index.js';
 export { summarize } from './summarize.js';
 export type {
   AnthropicConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,18 @@
+export { DefluffError } from './errors.js';
+export type { DefluffErrorCode } from './errors.js';
+export { parseBullets } from './parse.js';
+export { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
+export { PROVIDER_KINDS } from './providers/index.js';
+export { summarize } from './summarize.js';
+export type {
+  AnthropicConfig,
+  GeminiConfig,
+  OpenAICompatibleConfig,
+  OpenAIConfig,
+  ProviderAdapter,
+  ProviderConfig,
+  ProviderKind,
+  ProviderRunArgs,
+  Summary,
+  SummarizeOptions,
+} from './types.js';

--- a/packages/core/src/parse.test.ts
+++ b/packages/core/src/parse.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { parseBullets } from './parse.js';
+
+describe('parseBullets', () => {
+  it('parses dash bullets', () => {
+    const raw = '- First point\n- Second point\n- Third';
+    expect(parseBullets(raw)).toEqual(['First point', 'Second point', 'Third']);
+  });
+
+  it('parses asterisk and unicode bullets', () => {
+    expect(parseBullets('* alpha\n• beta\n· gamma')).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('parses numbered lists (dot and paren)', () => {
+    expect(parseBullets('1. first\n2) second\n10. tenth')).toEqual(['first', 'second', 'tenth']);
+  });
+
+  it('drops preamble and trailing lines without markers', () => {
+    const raw = [
+      'Here are the key points:',
+      '',
+      '- Need a timeline by Friday',
+      '- Budget cap is $5k',
+      '',
+      'Let me know if you need anything else.',
+    ].join('\n');
+    expect(parseBullets(raw)).toEqual(['Need a timeline by Friday', 'Budget cap is $5k']);
+  });
+
+  it('strips inline bold markup', () => {
+    expect(parseBullets('- **Urgent**: send the deck\n- __blocker__ resolved')).toEqual([
+      'Urgent: send the deck',
+      'blocker resolved',
+    ]);
+  });
+
+  it('returns empty array when no bullets present', () => {
+    expect(parseBullets('This response has no bullets at all.')).toEqual([]);
+  });
+});

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -1,0 +1,29 @@
+const BULLET_PATTERNS: readonly RegExp[] = [
+  /^[-*•·]\s+(.+)$/,
+  /^\d+[.)]\s+(.+)$/,
+];
+
+/**
+ * Extract bullet strings from a model response. Lenient: accepts `-`, `*`, `•`,
+ * `·`, `1.`, `1)` markers. Lines without a recognized marker are ignored, so a
+ * preamble like "Here are the key points:" gets silently dropped.
+ */
+export function parseBullets(raw: string): string[] {
+  const bullets: string[] = [];
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    for (const pattern of BULLET_PATTERNS) {
+      const match = pattern.exec(line);
+      if (match && match[1]) {
+        bullets.push(stripInlineBold(match[1].trim()));
+        break;
+      }
+    }
+  }
+  return bullets;
+}
+
+function stripInlineBold(s: string): string {
+  return s.replace(/\*\*(.+?)\*\*/g, '$1').replace(/__(.+?)__/g, '$1');
+}

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,0 +1,16 @@
+/**
+ * The exact extraction prompt is load-bearing. Do not soften, expand, or rephrase
+ * without updating requirements.md §4.4 — this wording is what keeps the output
+ * terse and fluff-free. Loosening it reintroduces the padding the product exists
+ * to remove.
+ */
+export const SYSTEM_PROMPT =
+  'You are an extraction tool. Analyze the following email. Strip away all ' +
+  'pleasantries, corporate jargon, and likely AI-generated padding. Output only ' +
+  "the core facts, the sender's underlying intent, and any specific action items " +
+  'or questions requested. Format strictly as a concise, 3-5 bullet point list. ' +
+  'Do not add conversational filler.';
+
+export function buildUserPrompt(emailText: string): string {
+  return `<email>\n${emailText.trim()}\n</email>`;
+}

--- a/packages/core/src/providers/anthropic.ts
+++ b/packages/core/src/providers/anthropic.ts
@@ -1,0 +1,67 @@
+import { codeFromStatus, DefluffError } from '../errors.js';
+import type { AnthropicConfig, ProviderAdapter, ProviderRunArgs } from '../types.js';
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const API_VERSION = '2023-06-01';
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+  error?: { type?: string; message?: string };
+}
+
+export const anthropicAdapter: ProviderAdapter<AnthropicConfig> = {
+  async run(config, args) {
+    return callAnthropic(config, args);
+  },
+};
+
+async function callAnthropic(
+  config: AnthropicConfig,
+  args: ProviderRunArgs,
+): Promise<string> {
+  const body = {
+    model: config.model ?? DEFAULT_MODEL,
+    max_tokens: 512,
+    system: args.systemPrompt,
+    messages: [{ role: 'user', content: args.userPrompt }],
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': config.apiKey,
+        'anthropic-version': API_VERSION,
+        // Opt in to browser-origin requests. Safe here because the key is the
+        // user's own (BYOK), stored in per-user encrypted extension storage.
+        'anthropic-dangerous-direct-browser-access': 'true',
+      },
+      body: JSON.stringify(body),
+      ...(args.signal ? { signal: args.signal } : {}),
+    });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') {
+      throw new DefluffError('aborted', 'Request aborted', { cause });
+    }
+    throw new DefluffError('network', 'Network request to Anthropic failed', { cause });
+  }
+
+  const json = (await response.json().catch(() => ({}))) as AnthropicResponse;
+
+  if (!response.ok) {
+    throw new DefluffError(
+      codeFromStatus(response.status),
+      json.error?.message ?? `Anthropic request failed: ${response.status}`,
+      { status: response.status, detail: json.error },
+    );
+  }
+
+  const text = json.content?.find((block) => block.type === 'text')?.text;
+  if (!text) {
+    throw new DefluffError('server', 'Anthropic response contained no text block', { detail: json });
+  }
+  return text;
+}

--- a/packages/core/src/providers/gemini.ts
+++ b/packages/core/src/providers/gemini.ts
@@ -1,0 +1,54 @@
+import { codeFromStatus, DefluffError } from '../errors.js';
+import type { GeminiConfig, ProviderAdapter, ProviderRunArgs } from '../types.js';
+
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+interface GeminiResponse {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  error?: { code?: number; message?: string; status?: string };
+}
+
+export const geminiAdapter: ProviderAdapter<GeminiConfig> = {
+  async run(config, args) {
+    const model = config.model ?? DEFAULT_MODEL;
+    const url = `${API_BASE}/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(config.apiKey)}`;
+
+    const body = {
+      systemInstruction: { parts: [{ text: args.systemPrompt }] },
+      contents: [{ role: 'user', parts: [{ text: args.userPrompt }] }],
+      generationConfig: { maxOutputTokens: 512 },
+    };
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        ...(args.signal ? { signal: args.signal } : {}),
+      });
+    } catch (cause) {
+      if (cause instanceof DOMException && cause.name === 'AbortError') {
+        throw new DefluffError('aborted', 'Request aborted', { cause });
+      }
+      throw new DefluffError('network', 'Network request to Gemini failed', { cause });
+    }
+
+    const json = (await response.json().catch(() => ({}))) as GeminiResponse;
+
+    if (!response.ok) {
+      throw new DefluffError(
+        codeFromStatus(response.status),
+        json.error?.message ?? `Gemini request failed: ${response.status}`,
+        { status: response.status, detail: json.error },
+      );
+    }
+
+    const text = json.candidates?.[0]?.content?.parts?.find((p) => p.text)?.text;
+    if (!text) {
+      throw new DefluffError('server', 'Gemini response contained no text part', { detail: json });
+    }
+    return text;
+  },
+};

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -1,0 +1,14 @@
+import type { ProviderKind } from '../types.js';
+import { anthropicAdapter } from './anthropic.js';
+import { geminiAdapter } from './gemini.js';
+import { openaiAdapter } from './openai.js';
+import { openaiCompatibleAdapter } from './openai-compatible.js';
+
+export const PROVIDER_KINDS: readonly ProviderKind[] = [
+  'anthropic',
+  'openai',
+  'gemini',
+  'openai-compatible',
+] as const;
+
+export { anthropicAdapter, geminiAdapter, openaiAdapter, openaiCompatibleAdapter };

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -11,4 +11,23 @@ export const PROVIDER_KINDS: readonly ProviderKind[] = [
   'openai-compatible',
 ] as const;
 
+/**
+ * Default model IDs for each provider. UIs use these as placeholder text
+ * in the model-override field. Update these in one place when a provider
+ * ships a better default — do not duplicate in client apps.
+ */
+export const PROVIDER_DEFAULT_MODELS: Record<ProviderKind, string> = {
+  anthropic: 'claude-haiku-4-5-20251001',
+  openai: 'gpt-4o-mini',
+  gemini: 'gemini-2.5-flash',
+  'openai-compatible': 'llama3',
+};
+
+export const PROVIDER_LABELS: Record<ProviderKind, string> = {
+  anthropic: 'Anthropic Claude',
+  openai: 'OpenAI',
+  gemini: 'Google Gemini',
+  'openai-compatible': 'OpenAI-compatible (Ollama, LM Studio, custom)',
+};
+
 export { anthropicAdapter, geminiAdapter, openaiAdapter, openaiCompatibleAdapter };

--- a/packages/core/src/providers/openai-compatible.ts
+++ b/packages/core/src/providers/openai-compatible.ts
@@ -1,0 +1,67 @@
+import { codeFromStatus, DefluffError } from '../errors.js';
+import type { OpenAICompatibleConfig, ProviderAdapter, ProviderRunArgs } from '../types.js';
+
+interface ChatCompletionsResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+  error?: { message?: string; type?: string };
+}
+
+export const openaiCompatibleAdapter: ProviderAdapter<OpenAICompatibleConfig> = {
+  async run(config, args) {
+    return callOpenAICompatible(
+      { baseUrl: config.baseUrl, apiKey: config.apiKey, model: config.model },
+      args,
+    );
+  },
+};
+
+export async function callOpenAICompatible(
+  config: { baseUrl: string; apiKey?: string; model: string },
+  args: ProviderRunArgs,
+): Promise<string> {
+  const url = `${config.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (config.apiKey) {
+    headers.authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const body = {
+    model: config.model,
+    max_tokens: 512,
+    messages: [
+      { role: 'system', content: args.systemPrompt },
+      { role: 'user', content: args.userPrompt },
+    ],
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      ...(args.signal ? { signal: args.signal } : {}),
+    });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') {
+      throw new DefluffError('aborted', 'Request aborted', { cause });
+    }
+    throw new DefluffError('network', `Network request to ${url} failed`, { cause });
+  }
+
+  const json = (await response.json().catch(() => ({}))) as ChatCompletionsResponse;
+
+  if (!response.ok) {
+    throw new DefluffError(
+      codeFromStatus(response.status),
+      json.error?.message ?? `Request failed: ${response.status}`,
+      { status: response.status, detail: json.error },
+    );
+  }
+
+  const text = json.choices?.[0]?.message?.content;
+  if (!text) {
+    throw new DefluffError('server', 'Response contained no message content', { detail: json });
+  }
+  return text;
+}

--- a/packages/core/src/providers/openai.ts
+++ b/packages/core/src/providers/openai.ts
@@ -1,0 +1,18 @@
+import type { OpenAIConfig, ProviderAdapter } from '../types.js';
+import { callOpenAICompatible } from './openai-compatible.js';
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+
+export const openaiAdapter: ProviderAdapter<OpenAIConfig> = {
+  async run(config, args) {
+    return callOpenAICompatible(
+      {
+        baseUrl: DEFAULT_BASE_URL,
+        apiKey: config.apiKey,
+        model: config.model ?? DEFAULT_MODEL,
+      },
+      args,
+    );
+  },
+};

--- a/packages/core/src/summarize.test.ts
+++ b/packages/core/src/summarize.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefluffError } from './errors.js';
+import { summarize } from './summarize.js';
+
+function mockFetchOnce(status: number, payload: unknown): void {
+  const response = new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
+}
+
+describe('summarize', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed bullets from an OpenAI-shaped response', async () => {
+    mockFetchOnce(200, {
+      choices: [
+        {
+          message: {
+            content: '- Need signoff by EOD Thursday\n- Blocker: missing legal review\n- Meeting tomorrow 10am',
+          },
+        },
+      ],
+    });
+
+    const result = await summarize({
+      text: 'Hi team, hope you are well...',
+      provider: { kind: 'openai', apiKey: 'sk-test' },
+    });
+
+    expect(result.bullets).toHaveLength(3);
+    expect(result.bullets[0]).toBe('Need signoff by EOD Thursday');
+  });
+
+  it('rejects empty email text', async () => {
+    await expect(
+      summarize({ text: '   ', provider: { kind: 'openai', apiKey: 'sk-test' } }),
+    ).rejects.toBeInstanceOf(DefluffError);
+  });
+
+  it('throws no_bullets when the model returns prose only', async () => {
+    mockFetchOnce(200, {
+      choices: [{ message: { content: 'The sender wants help with the deck.' } }],
+    });
+
+    await expect(
+      summarize({
+        text: 'Hey, about the deck...',
+        provider: { kind: 'openai', apiKey: 'sk-test' },
+      }),
+    ).rejects.toMatchObject({ code: 'no_bullets' });
+  });
+
+  it('maps a 401 response to an auth error', async () => {
+    mockFetchOnce(401, { error: { message: 'Invalid API key' } });
+
+    await expect(
+      summarize({
+        text: 'anything',
+        provider: { kind: 'openai', apiKey: 'sk-bad' },
+      }),
+    ).rejects.toMatchObject({ code: 'auth', status: 401 });
+  });
+});

--- a/packages/core/src/summarize.ts
+++ b/packages/core/src/summarize.ts
@@ -1,0 +1,45 @@
+import { DefluffError } from './errors.js';
+import { parseBullets } from './parse.js';
+import { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
+import {
+  anthropicAdapter,
+  geminiAdapter,
+  openaiAdapter,
+  openaiCompatibleAdapter,
+} from './providers/index.js';
+import type { ProviderConfig, ProviderRunArgs, Summary, SummarizeOptions } from './types.js';
+
+export async function summarize(opts: SummarizeOptions): Promise<Summary> {
+  const { text, provider, signal } = opts;
+  if (!text.trim()) {
+    throw new DefluffError('bad_request', 'Email text is empty.');
+  }
+
+  const args: ProviderRunArgs = {
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt: buildUserPrompt(text),
+    ...(signal ? { signal } : {}),
+  };
+
+  const raw = await dispatchProvider(provider, args);
+  const bullets = parseBullets(raw);
+  if (bullets.length === 0) {
+    throw new DefluffError('no_bullets', 'Provider returned no parseable bullets.', {
+      detail: { raw },
+    });
+  }
+  return { bullets };
+}
+
+function dispatchProvider(provider: ProviderConfig, args: ProviderRunArgs): Promise<string> {
+  switch (provider.kind) {
+    case 'anthropic':
+      return anthropicAdapter.run(provider, args);
+    case 'openai':
+      return openaiAdapter.run(provider, args);
+    case 'gemini':
+      return geminiAdapter.run(provider, args);
+    case 'openai-compatible':
+      return openaiCompatibleAdapter.run(provider, args);
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,52 @@
+export type ProviderKind = 'anthropic' | 'openai' | 'gemini' | 'openai-compatible';
+
+export interface AnthropicConfig {
+  kind: 'anthropic';
+  apiKey: string;
+  model?: string;
+}
+
+export interface OpenAIConfig {
+  kind: 'openai';
+  apiKey: string;
+  model?: string;
+}
+
+export interface GeminiConfig {
+  kind: 'gemini';
+  apiKey: string;
+  model?: string;
+}
+
+export interface OpenAICompatibleConfig {
+  kind: 'openai-compatible';
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+}
+
+export type ProviderConfig =
+  | AnthropicConfig
+  | OpenAIConfig
+  | GeminiConfig
+  | OpenAICompatibleConfig;
+
+export interface Summary {
+  bullets: string[];
+}
+
+export interface SummarizeOptions {
+  text: string;
+  provider: ProviderConfig;
+  signal?: AbortSignal;
+}
+
+export interface ProviderRunArgs {
+  systemPrompt: string;
+  userPrompt: string;
+  signal?: AbortSignal;
+}
+
+export interface ProviderAdapter<Cfg extends ProviderConfig> {
+  run(config: Cfg, args: ProviderRunArgs): Promise<string>;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2216 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/extension:
+    dependencies:
+      '@defluff/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@crxjs/vite-plugin':
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
+      '@types/chrome':
+        specifier: ^0.0.287
+        version: 0.0.287
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17))
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)
+
+  apps/outlook-addin:
+    dependencies:
+      '@defluff/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@types/office-js':
+        specifier: ^1.0.460
+        version: 1.0.589
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^1.2.0
+        version: 1.2.0(vite@6.4.2(@types/node@22.19.17))
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)
+
+  packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@crxjs/vite-plugin@2.0.0-beta.29':
+    resolution: {integrity: sha512-BavhDs/WvuBuS0WR3K1IIPgDt1/Pr+wqaQ0ID2/JeyNexokTxVoXXTH8DShtqpjByomBc+5w6sW8OI95vTO2nw==}
+    deprecated: Beta versions are no longer maintained. Please upgrade to the stable 2.0.0 release
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chrome@0.0.287':
+    resolution: {integrity: sha512-wWhBNPNXZHwycHKNYnexUcpSbrihVZu++0rdp6GEk5ZgAglenLx+RwdEouh6FrHS0XQiOxSd62yaujM1OoQlZQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/office-js@1.0.589':
+    resolution: {integrity: sha512-VN0DL4Px93PsHpwwRjygfvcvrSAGLnvGIrxo1kYaa9YY2qpSgJfQy3jyfqWSJ4LmOP6TMGjil+ZeAbmLFnR4nw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-basic-ssl@1.2.0':
+    resolution: {integrity: sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@webcomponents/custom-elements@1.6.0':
+    resolution: {integrity: sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  electron-to-chromium@1.5.340:
+    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@0.10.5:
+    resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.13.0:
+    resolution: {integrity: sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==}
+    engines: {node: '>=0.10.0'}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@2.79.2:
+    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.5.7:
+    resolution: {integrity: sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@crxjs/vite-plugin@2.0.0-beta.29':
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      '@webcomponents/custom-elements': 1.6.0
+      acorn-walk: 8.3.5
+      cheerio: 1.2.0
+      convert-source-map: 1.9.0
+      debug: 4.4.3
+      es-module-lexer: 0.10.5
+      fast-glob: 3.3.3
+      fs-extra: 10.1.0
+      jsesc: 3.1.0
+      magic-string: 0.30.21
+      picocolors: 1.1.1
+      react-refresh: 0.13.0
+      rollup: 2.79.2
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.2
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/chrome@0.0.287':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
+  '@types/estree@1.0.8': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/office-js@1.0.589': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-basic-ssl@1.2.0(vite@6.4.2(@types/node@22.19.17))':
+    dependencies:
+      vite: 6.4.2(@types/node@22.19.17)
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  '@webcomponents/custom-elements@1.6.0': {}
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  assertion-error@2.0.1: {}
+
+  baseline-browser-mapping@2.10.20: {}
+
+  boolbase@1.0.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.20
+      caniuse-lite: 1.0.30001788
+      electron-to-chromium: 1.5.340
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001788: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
+
+  convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  electron-to-chromium@1.5.340: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  es-module-lexer@0.10.5: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  graceful-fs@4.2.11: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.37: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.13.0: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.5: {}
+
+  reusify@1.1.0: {}
+
+  rollup@2.79.2:
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  rxjs@7.5.7:
+    dependencies:
+      tslib: 2.8.1
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
+
+  universalify@2.0.1: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vite@6.4.2(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  yallist@3.1.1: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
+  }
+}


### PR DESCRIPTION
## Summary

Scaffolds the four deliverables defined in `requirements.md`:

| Path | What |
|---|---|
| `packages/core` | Shared extraction prompt, provider adapters (Anthropic, OpenAI, Gemini, OpenAI-compatible), bullet parser, `summarize()` orchestrator, typed errors, 10 vitest tests |
| `apps/extension` | MV3 extension for Gmail + Outlook Web. React options page, shadow-DOM content UI, host-scoped permissions only, background service worker owns all LLM calls |
| `apps/outlook-addin` | Office.js add-in. XML manifest, plain-TS task pane, `Office.context.roamingSettings` for credentials, reads email via `item.body.getAsync(Text)` |
| `apps/openclaw-skill` | Single `SKILL.md` (markdown + YAML) using the same extraction prompt. Published to ClawHub |

Architectural decisions baked in (see `CLAUDE.md`):
- **No backend.** BYOK direct from each client to the user's chosen LLM. Zero-retention becomes structural rather than policy.
- **Extraction prompt is load-bearing.** Verbatim from `requirements.md` §4.4 in `packages/core/src/prompt.ts`.
- **Provider defaults and labels** centralized in `@defluff/core` so UIs stay in sync automatically.

## Verification

- `pnpm -r typecheck` — clean across all 3 TS packages.
- `pnpm --filter @defluff/core test` — 10/10 passing (parser edge cases + summarize happy/error paths).
- `pnpm --filter @defluff/extension build` — bundles clean.
- `pnpm --filter @defluff/outlook-addin build` — bundles clean.

## Intentionally stubbed (follow-up issues recommended)

- **Extension icons**: omitted from manifest. Need 16/48/128 PNGs before Chrome Web Store submission.
- **Outlook icons + Id GUID + production URLs**: manifest references `https://localhost:3000` and a placeholder GUID — fine for dev sideloading, must be swapped before AppSource.
- **Gmail DOM selectors**: best-effort starting point. Gmail's DOM is unstable and needs iteration against live UI. Current placement injects next to the subject heading — spec §2.A prefers near Reply/Forward (`.btC`). TODO in `apps/extension/src/content/hosts/gmail.ts`.
- **Outlook Web DOM selectors**: same story — works against current Outlook Web but fragile.
- **`packages/proxy` (optional Cloudflare Worker)**: not built. Only needed if a provider blocks a real-world add-in origin; verify with live traffic before investing.
- **CORS smoke test**: Anthropic/OpenAI/Gemini SDK docs claim browser support, but the task pane webview origin needs a live test against each provider.

## Test plan

- [ ] Load the unpacked extension into Chrome (`apps/extension/dist`), configure Anthropic, and verify the De-Fluff button appears on a Gmail thread
- [ ] Sideload `apps/outlook-addin/manifest.xml` into Outlook Web, click the ribbon button, verify task pane opens and summarizes an open message
- [ ] Copy `apps/openclaw-skill/SKILL.md` into `~/.openclaw/workspace/skills/defluff/` and invoke via Openclaw chat
- [ ] Verify Ollama path end-to-end by pointing the OpenAI-compatible provider at `http://localhost:11434/v1`