### PR TITLE
chore: launch prep — CI, SECURITY.md, CONTRIBUTING.md, launch kit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r typecheck
+
+      - run: pnpm -r test
+
+      - run: pnpm -r build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Defluff
+
+Thanks for looking! This is a small project with a focused goal — strip AI-generated padding from emails into 3-5 bullets — and contributions that stay close to that goal are the most likely to land.
+
+## Prerequisites
+
+- Node.js 22+
+- pnpm 9.15.0 (pinned via `packageManager` in `package.json`)
+- A real Gmail or Outlook account for live-testing extension changes
+
+## Setup
+
+```bash
+git clone https://github.com/FinAegis/defluff.git
+cd defluff
+pnpm install
+```
+
+## Daily workflow
+
+```bash
+pnpm -r typecheck      # type-check every package
+pnpm -r test           # run vitest across all packages
+pnpm -r build          # build both clients
+
+# single-package work
+pnpm --filter @defluff/core test:watch
+pnpm --filter @defluff/extension dev      # Vite dev + HMR for the browser extension
+pnpm --filter @defluff/outlook-addin dev  # HTTPS dev server for the Outlook add-in
+```
+
+To load the extension into Chrome:
+1. `pnpm --filter @defluff/extension build`
+2. `chrome://extensions` → enable Developer mode → **Load unpacked** → pick `apps/extension/dist`
+3. Open the extension's options page (Details → Extension options) and configure a provider
+
+## Architecture
+
+| Path | Owns |
+|---|---|
+| `packages/core` | Extraction prompt, provider adapters, response parser, summarize orchestrator. **No DOM, no platform APIs, no UI.** Pure TS |
+| `apps/extension` | MV3 browser extension. Service worker calls core; content scripts render UI |
+| `apps/outlook-addin` | Office.js add-in. Task pane calls core directly from the webview |
+| `apps/openclaw-skill` | Pure markdown + YAML, no code |
+
+All clients consume `@defluff/core` — if something is cross-cutting (provider-knowledge, config validation, the extraction prompt), it belongs in core, not in a client.
+
+## Hard constraints
+
+These are non-negotiable. PRs that violate them will be closed with a pointer back here.
+
+- **No backend.** The zero-retention story is structural, not policy. If a PR adds an intermediate server, close it.
+- **Extension permissions are host-scoped.** Never request `<all_urls>` in `manifest.config.ts`.
+- **The extraction prompt is verbatim from `requirements.md` §4.4.** Changes to the prompt require updating that spec document and must have a strong reason — loosening the wording reintroduces the fluff we exist to remove.
+- **No analytics / telemetry SDKs.** Crash reporting, if ever added, must be opt-in and body-scrubbing.
+
+## Commit and PR style
+
+- Conventional commit subjects (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `ci:`, `test:`). Scope with the package name when useful: `feat(extension): ...`.
+- One logical change per PR. Scaffolding PRs can be larger; bug fixes should be small and focused.
+- Include the motivation in the commit body — *why* the change, not just *what*.
+- For user-visible changes in the browser/add-in UI, include a screenshot or a short recording.
+
+## Where to start
+
+Issues tagged **[good first issue](https://github.com/FinAegis/defluff/labels/good%20first%20issue)** are usually self-contained and well-specified.
+
+If you want to take on something bigger, look at **[launch-blocker](https://github.com/FinAegis/defluff/labels/launch-blocker)** — those are the real-world testing and DOM-selector passes needed before v0.1 ships.
+
+## Testing guidelines
+
+- Core logic changes must land with tests (`packages/core/src/*.test.ts`). Aim for one failing test per bug you're fixing.
+- Extension content-script changes should come with a manual test note in the PR description: what Gmail/Outlook view you tested, on which provider.
+- DOM-selector updates must include a dated comment next to the selector noting when it was last audited against the live UI.
+
+## Code of conduct
+
+Be kind, be direct, stay technical. We don't need a big formal CoC yet — if that changes, we'll add one.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security
+
+Defluff runs entirely in the user's browser. There is no FinAegis-operated backend — no server that receives email text, stores API keys, or processes requests on your behalf. This shapes our threat model.
+
+## Architecture at a glance
+
+```
+  your browser / Outlook webview
+  ─────────────────────────────────
+  [De-Fluff button] ──► [email body text] ──► [user's LLM provider]
+                                                ↑
+                                   (api.anthropic.com / api.openai.com /
+                                    generativelanguage.googleapis.com /
+                                    user-chosen OpenAI-compatible URL)
+```
+
+Your email body and your API key travel one edge: from your browser to the provider you picked. Neither passes through any Defluff infrastructure.
+
+## What we commit to
+
+| Property | How it's enforced |
+|---|---|
+| **Zero retention of email content** | Structural — there's no server to retain on |
+| **No analytics or telemetry** | We ship zero analytics SDKs. If we ever need crash reports, they will be opt-in and scrubbed of request bodies |
+| **Minimal permissions** | Extension requests host-specific permissions only (`mail.google.com`, `outlook.office.com`, and the exact LLM endpoints). Never `<all_urls>` |
+| **API key storage** | `chrome.storage.sync` (encrypted at rest by Chrome) for the extension; `Office.context.roamingSettings` for the Outlook add-in. Per-user, per-device, synced by the platform |
+| **Transport security** | All LLM requests use HTTPS. Local Ollama endpoints are an exception — documented in the options page |
+| **Source availability** | MIT licensed. Anyone can audit the code, and we encourage reproducible builds |
+
+## What's explicitly in scope for security concerns
+
+- **DOM injection into Gmail / Outlook Web.** Content scripts inject UI into these hosts. All user-visible text goes through `textContent`, never `innerHTML`. Shadow DOM isolates our styles from the host page (and vice versa).
+- **LLM response rendering.** The model returns bullet strings. These are rendered as `textContent` on `<li>` elements — no HTML parsing, no XSS surface even if the model were adversarial.
+- **Runtime validation of stored values.** `isProviderConfig()` rejects malformed persisted data. If someone tampered with `chrome.storage.sync`, we fail closed rather than crash.
+- **Message-passing boundary.** The background service worker only listens to intra-extension messages (`chrome.runtime.onMessage`, not `onMessageExternal`) and validates the request shape before dispatching.
+
+## What's explicitly out of scope
+
+- **Your LLM provider's security.** If Anthropic, OpenAI, or Google is compromised, your emails are exposed. That's the provider's responsibility, not ours. The BYOK model means you pick the trust anchor.
+- **Your device security.** If your machine is compromised, so is everything running on it — your API key, your browser session, your email. We can't protect against a rooted OS.
+- **`chrome.storage.sync` encryption.** Chrome encrypts sync storage at rest, but the keys are yours to trust Google with. If you don't trust Chrome Sync, use a separate profile for Defluff or paste your API key each session (future feature).
+- **Prompt injection via email content.** A sender can include text like "ignore previous instructions and…" in the email body. The model may follow it. The output is rendered as text, so there's no code-execution risk, but the bullets may be wrong or misleading. Don't take action on a Defluff summary of a suspicious sender's email without reading the original.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security bugs.
+
+Open a private advisory via GitHub: https://github.com/FinAegis/defluff/security/advisories/new
+
+Include:
+- A description of the vulnerability and how you found it.
+- Reproduction steps or a proof of concept.
+- The affected component (extension, Outlook add-in, core package, Openclaw skill).
+- The versions you tested against.
+
+We aim to acknowledge within 3 business days and to ship a fix within 14 days for high-severity issues. Coordinated disclosure preferred — we'll agree on a publication date with you before any public write-up.

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -1,0 +1,137 @@
+# Launch Materials
+
+Draft copy for the Defluff launch. Keep this file updated as the product evolves — the Show HN post and landing copy should always reflect what currently ships.
+
+## The wedge
+
+> **AI wrote this email. Have AI read it.**
+
+Nine-word pitch. Use everywhere. It works because:
+- It captures the entire value prop.
+- It's an inversion — memorable, quotable, reposted as-is.
+- It sets up the privacy narrative: you're not trusting a new SaaS, you're turning the AI arms race back on itself with your own tools.
+
+## Show HN post (draft)
+
+**Title:** `Show HN: Defluff – strip AI-generated fluff from emails (BYOK, open source)`
+
+---
+
+Corporate email has become unreadable. Half of every message is AI-generated filler, restated context, and "I hope this finds you well." Defluff is a browser extension and Outlook add-in that replaces the body of an open email with 3–5 bullets of what the sender actually wants.
+
+The interesting part isn't the summarization — that's just an LLM call with a restrictive prompt. The interesting part is the trust model. There is no Defluff backend. Your email body and your API key never leave your browser for any infrastructure we run. Each De-Fluff click goes straight from your browser to the provider you picked (Anthropic, OpenAI, Gemini, or local Ollama). Zero retention isn't a policy, it's the architecture.
+
+This means:
+- Your corporate IT has nothing to ban — we're not processing their data.
+- Self-hosters can point it at Ollama and never pay for a cloud inference call.
+- If you don't trust us, you can audit every line — it's MIT licensed, ~2k LOC TS total.
+
+The pieces:
+- Chrome/Edge/Firefox extension for Gmail and Outlook Web.
+- Office.js add-in for desktop Outlook (Windows and Mac) and Outlook Web.
+- An Openclaw skill for the local-agents crowd.
+
+Everything shares one ~500-line `@defluff/core` package that owns the extraction prompt and the four provider adapters. Plain `fetch()` — no SDKs in the bundle.
+
+Feedback welcome, especially from anyone whose enterprise has banned every mainstream AI summarizer on data-residency grounds. That's who this was built for.
+
+Repo: https://github.com/FinAegis/defluff
+Landing: https://defluff.app (coming)
+
+---
+
+**Post-launch reply kit** — canned answers for common HN questions:
+
+- *"Why not use the Anthropic SDK?"* — Keeps the extension bundle small and the dependency audit surface minimal. Four plain-fetch adapters is ~200 LOC total. SDK adoption is deferred until there's a real reason.
+- *"How do you handle prompt injection in emails?"* — Output renders as `textContent`, so there's no code-execution risk. The summary can be wrong or misleading if the sender is adversarial, and we document that in SECURITY.md. Don't act on a Defluff summary of a suspicious sender.
+- *"Why BYOK instead of a subscription?"* — Two reasons. Privacy (covered above). And commitment: the moment we have a subscription, we're incentivized to upsell features that dilute the product's focus. BYOK keeps us honest.
+- *"Does it work with Fastmail / ProtonMail / Thunderbird / Apple Mail?"* — Not yet. The architecture could extend to those; it's a matter of which client sees enough demand. Open an issue if you want one.
+
+## Landing page copy
+
+Single-page. Three sections: hero, how it works, the privacy sell. One CTA.
+
+### Hero
+
+**AI wrote this email.**
+**Have AI read it.**
+
+Defluff strips corporate fluff from Gmail and Outlook in one click. Zero servers. Your keys, your models, your data.
+
+**[Install for Chrome]** **[Install for Outlook]**
+
+*(before/after screenshot: 400-word corporate email on the left, 3-bullet defluffed version on the right)*
+
+### How it works
+
+1. **Install** the extension or Outlook add-in.
+2. **Configure** your LLM provider — Anthropic, OpenAI, Gemini, or your local Ollama. Any of them. Your key, in your browser.
+3. **Click De-Fluff** on any email. The message collapses into the 3–5 points that actually matter.
+
+### The privacy sell
+
+| | Defluff | Shortwave | Superhuman AI | Grammarly |
+|---|---|---|---|---|
+| Your email reaches their servers | **Never** | Yes | Yes | Yes |
+| Stores your content | **Never** | Yes | Yes | Yes |
+| Needs an account | **No** | Yes | Yes | Yes |
+| Costs per month | **$0*** | \$12 | \$40 | \$12 |
+| Open source | **Yes** | No | No | No |
+| Works with local models | **Yes (Ollama)** | No | No | No |
+
+*\* Plus whatever you pay your chosen LLM provider. Typical cost for a heavy user: under $1/month on Claude Haiku or GPT-4o mini. $0 on Ollama.*
+
+### Proof points
+
+- MIT licensed
+- Zero analytics or telemetry
+- Host-scoped permissions (`mail.google.com`, `outlook.office.com` — nothing else)
+- Threat model published: [SECURITY.md](https://github.com/FinAegis/defluff/blob/main/SECURITY.md)
+- ~2,000 lines of TypeScript total. Audit it over coffee.
+
+## Channel-specific tweaks
+
+### Hacker News (Show HN)
+
+Lead with architecture. Audience respects "no backend" more than it respects "looks nice." The full post above is tuned for HN.
+
+### r/LocalLLaMA
+
+Lead with Ollama. One line: *"Your email summarizer doesn't have to leave your LAN."*
+
+### r/selfhosted
+
+Same as LocalLLaMA. Include a note about the optional self-hostable `packages/proxy` if/when it exists.
+
+### r/privacy
+
+Lead with the comparison table. The privacy row is the whole pitch.
+
+### Product Hunt (later — not day 1)
+
+Lead with the before/after screenshot. Wait until there are 1000+ installs from HN — PH rewards social proof more than novelty.
+
+### Enterprise / B2B outreach
+
+Lead with "your organization's CISO already banned Grammarly and Otter." Skip the technical architecture; reach for the compliance-team win: *nothing is processed on our servers, so no DPA, no sub-processor disclosure, no data-residency question.*
+
+## Launch checklist
+
+- [ ] All [launch-blocker issues](https://github.com/FinAegis/defluff/labels/launch-blocker) closed
+- [ ] Before/after screenshot in the README and landing
+- [ ] 20-second demo video (no voiceover; one click, three bullets, done)
+- [ ] Landing page live
+- [ ] Chrome Web Store listing approved
+- [ ] Edge Add-ons listing approved
+- [ ] Firefox AMO submission in queue
+- [ ] AppSource submission in queue
+- [ ] ClawHub skill published
+- [ ] Show HN post drafted (above) — post Tuesday or Wednesday 8am PT
+- [ ] Maintainer available for 24h to reply to comments
+- [ ] Pre-warmed on r/LocalLLaMA and r/selfhosted as follow-up posts
+
+## What not to do
+
+- Don't Product Hunt-first. HN converts better for this profile and sets the narrative.
+- Don't add telemetry to measure the launch. The zero-retention story is load-bearing. GitHub stars + Chrome Web Store installs are the only metrics.
+- Don't over-promise. Ship v0.1 with what works and let people find the rest.


### PR DESCRIPTION
Infra and docs groundwork for shipping v0.1. No runtime code changes.

## What's in it

### `.github/workflows/ci.yml`
Runs typecheck + test + build on every PR and push to main. Matches the pnpm/node versions pinned in `package.json`. Cancels superseded runs via concurrency group.

### `SECURITY.md`
A written threat model for the BYOK/no-backend architecture. Enterprise users read this before installing; leaving it implicit costs us adoption.

### `CONTRIBUTING.md`
How to run locally, the architectural constraints that are non-negotiable (no backend, host-scoped permissions, verbatim extraction prompt), commit/PR conventions, and where to start.

### `docs/launch.md`
Internal launch kit — Show HN draft, post-launch reply kit for common HN questions, landing page copy, comparison table vs Shortwave/Superhuman/Grammarly, channel-specific tweaks for r/LocalLLaMA / r/selfhosted / r/privacy / enterprise outreach, and a launch checklist gated on the launch-blocker issues.

## Launch-blocker issues opened alongside this PR

- #3 — Add extension + Outlook add-in icons
- #4 — Live Gmail DOM pass + button placement per spec §2.A
- #5 — Live Outlook Web DOM pass
- #6 — CORS smoke test for direct-from-webview calls to each provider
- #7 — Publish v0.1 (meta-issue tracking Chrome Web Store / Edge / Firefox AMO / AppSource / ClawHub)

## Verification

- CI workflow is syntactically valid; will self-verify on this PR.
- No runtime code touched, so existing typecheck + test pass trivially.