### PR TITLE
feat(outlook-addin): GitHub Pages hosting + production manifest

### DIFF
--- a/.github/workflows/deploy-addin.yml
+++ b/.github/workflows/deploy-addin.yml
@@ -1,0 +1,58 @@
+name: Deploy Outlook add-in to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DEFLUFF_ADDIN_BASE_URL: https://finaegis.github.io/defluff
+      DEFLUFF_ADDIN_BASE_PATH: /defluff/
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter @defluff/outlook-addin build
+
+      - run: pnpm --filter @defluff/outlook-addin build:manifest
+
+      - name: Place production manifest at the Pages root
+        run: cp apps/outlook-addin/manifest.production.xml apps/outlook-addin/dist/manifest.xml
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/outlook-addin/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ web-ext-artifacts/
 
 # Office add-in
 .vs/
+apps/outlook-addin/manifest.production.xml
 
 # Vercel
 .vercel

--- a/apps/outlook-addin/README.md
+++ b/apps/outlook-addin/README.md
@@ -2,44 +2,64 @@
 
 Office Add-in for Outlook (desktop and web). Adds a **De-Fluff** ribbon button on the Message Read surface that opens a task pane with the bulleted summary.
 
-## Development
+## For end users — install the hosted add-in
+
+The add-in is built and published to GitHub Pages on every merge to main. To install:
+
+1. Download the production manifest: **https://finaegis.github.io/defluff/manifest.xml**
+2. **Outlook Web:** **Get Add-ins** → **My add-ins** → **Custom Addins** → **Add a custom add-in** → **Add from File** → pick the downloaded `manifest.xml`.
+3. **Outlook desktop (Windows/Mac):** same flow via **Get Add-ins** from the ribbon.
+4. Open any email — click the **De-Fluff** button in the ribbon to open the task pane and configure a provider.
+
+For org-wide deployment, your Microsoft 365 admin can upload the same manifest via the [Integrated apps](https://admin.microsoft.com/Adminportal/Home?source=applauncher#/Settings/IntegratedApps) console in the admin center.
+
+## For contributors — local dev
 
 ```bash
-pnpm install                                    # at the repo root
-pnpm --filter @defluff/outlook-addin dev        # starts Vite on https://localhost:3000
+pnpm install                              # at the repo root
+pnpm --filter @defluff/outlook-addin dev  # starts Vite on https://localhost:3000
 ```
 
-`@vitejs/plugin-basic-ssl` generates a self-signed cert automatically. The first time you hit `https://localhost:3000` you'll need to trust the cert in your browser (and for desktop Outlook, the OS cert store).
+`@vitejs/plugin-basic-ssl` generates a self-signed cert automatically. The first time you hit `https://localhost:3000` you'll need to trust the cert in your browser (and, for desktop Outlook, in your OS cert store).
 
-### Sideloading into Outlook
+### Sideloading the dev build
 
 1. Keep `pnpm dev` running.
-2. In Outlook (web): **Get Add-ins → My add-ins → Add a custom add-in → Add from File** and pick `manifest.xml`.
-3. Open a message. The **De-Fluff** button appears in the ribbon's Home tab.
-
-For desktop Outlook on Windows, install the manifest via **File → Options → Trust Center → Trust Center Settings → Trusted Add-in Catalogs** (shared network path) or use the [Microsoft 365 admin center](https://admin.microsoft.com) for org-wide deployment.
+2. In Outlook Web: **Get Add-ins → My add-ins → Custom Addins → Add a custom add-in → Add from File** and pick `apps/outlook-addin/manifest.xml` (the dev version, pointing at `https://localhost:3000`).
+3. Open a message — the **De-Fluff** button appears in the ribbon.
 
 ## Regenerating icons
 
-Icons live in `public/icons/` (Vite serves them at `https://localhost:3000/icons/*` in dev) and are generated from `assets/icon.svg` at the repo root:
+Icons live in `public/icons/` (Vite serves them at `/icons/*` in dev) and are generated from `assets/icon.svg` at the repo root:
 
 ```bash
 pnpm icons   # writes 16/32/64/80/128 PNGs to apps/outlook-addin/public/icons/
 ```
 
+## Build configuration
+
+Vite honors two env vars that the CI workflow sets for production builds:
+
+| Env var | Purpose |
+|---|---|
+| `DEFLUFF_ADDIN_BASE_PATH` | Vite `base` — must match the public URL subpath (e.g. `/defluff/` for GitHub Pages project sites). Defaults to `/`. |
+| `DEFLUFF_ADDIN_BASE_URL` | Absolute URL used by `build:manifest` to rewrite `https://localhost:3000` in `manifest.xml` to the production host. |
+
+Run `pnpm build:manifest` after a production build to generate `manifest.production.xml`.
+
 ## Known TODOs before AppSource / production
 
-- **Stable hosting URL**: replace every `https://localhost:3000` in `manifest.xml` with the production URL.
-- **Replace the Id GUID**: the current one is a dev-only placeholder. Generate a real GUID.
-- **AppSource validation**: Microsoft validates manifests strictly. Run `npx office-addin-manifest validate manifest.xml` before submission.
-- **CORS verification**: test direct calls from the task pane webview to each provider (Anthropic, OpenAI, Gemini). If any provider blocks the add-in origin, fall back to `packages/proxy` (Cloudflare Worker) rather than introducing a FinAegis-operated server.
+- **Replace the Id GUID**: `manifest.xml` still carries a dev-only placeholder. Generate a real GUID before AppSource submission.
+- **Validate**: run `npx office-addin-manifest validate manifest.production.xml` — AppSource validates manifests strictly.
+- **CORS verification**: see [#6](https://github.com/FinAegis/defluff/issues/6). Direct calls from the task pane to each provider need live testing; fall back to `packages/proxy` only if a provider blocks the Pages origin.
 
 ## Architecture
 
-- `manifest.xml` — Office Add-in manifest, targets the Message Read surface.
-- `src/taskpane/` — the pane UI. Plain TS + HTML + CSS (no React — keeps the bundle minimal).
-- `src/commands/` — function file. Currently unused (the ribbon button opens the task pane); reserved for future ExecuteFunction commands.
-- `src/shared/storage.ts` — `Office.context.roamingSettings` wrapper for storing the user's provider config (per-user, synced across devices by Office).
-- `src/shared/email.ts` — reads the current message body via `Office.context.mailbox.item.body.getAsync(Text)`.
+- `manifest.xml` — dev manifest (`https://localhost:3000`). Checked in.
+- `manifest.production.xml` — generated by `build:manifest` from `manifest.xml` with URL substitution. **Git-ignored** — CI writes it into the Pages deploy, users download it from `https://finaegis.github.io/defluff/manifest.xml`.
+- `src/taskpane/` — plain TS + HTML + CSS task pane.
+- `src/commands/` — function file referenced by the manifest. Reserved for future `ExecuteFunction` commands.
+- `src/shared/storage.ts` — `Office.context.roamingSettings` wrapper.
+- `src/shared/email.ts` — reads the current message body via `item.body.getAsync(Text)`.
 
-The task pane calls `@defluff/core.summarize()` directly. No backend, no service-worker indirection — the webview hits the user's chosen LLM endpoint.
+The task pane calls `@defluff/core.summarize()` directly — no backend, no service-worker indirection.

--- a/apps/outlook-addin/package.json
+++ b/apps/outlook-addin/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:manifest": "node scripts/build-production-manifest.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"

--- a/apps/outlook-addin/scripts/build-production-manifest.mjs
+++ b/apps/outlook-addin/scripts/build-production-manifest.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Generate apps/outlook-addin/manifest.production.xml from manifest.xml by
+// replacing the localhost dev URL with the hosted base URL. CI writes this
+// into the Pages artifact; end users download it from there to install the
+// add-in.
+//
+// Required env: DEFLUFF_ADDIN_BASE_URL (e.g. https://finaegis.github.io/defluff)
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, '..');
+
+const baseUrl = process.env.DEFLUFF_ADDIN_BASE_URL;
+if (!baseUrl) {
+  console.error('Set DEFLUFF_ADDIN_BASE_URL (e.g. https://finaegis.github.io/defluff).');
+  process.exit(1);
+}
+const normalized = baseUrl.replace(/\/$/, '');
+
+const src = readFileSync(join(pkgRoot, 'manifest.xml'), 'utf8');
+const out = src.replaceAll('https://localhost:3000', normalized);
+writeFileSync(join(pkgRoot, 'manifest.production.xml'), out);
+console.log(`wrote manifest.production.xml (base = ${normalized})`);

--- a/apps/outlook-addin/vite.config.ts
+++ b/apps/outlook-addin/vite.config.ts
@@ -2,8 +2,13 @@ import basicSsl from '@vitejs/plugin-basic-ssl';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  plugins: [basicSsl()],
+// DEFLUFF_ADDIN_BASE_PATH lets CI build with a subpath prefix for GitHub Pages
+// (e.g. /defluff/). Local dev leaves it unset so assets resolve at /.
+const basePath = process.env.DEFLUFF_ADDIN_BASE_PATH ?? '/';
+
+export default defineConfig(({ command }) => ({
+  base: basePath,
+  plugins: command === 'serve' ? [basicSsl()] : [],
   server: {
     port: 3000,
     strictPort: true,
@@ -18,4 +23,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
Closes the \"Outlook add-in is only dev-sideloadable\" gap. With this merged, any user can install the add-in by downloading one manifest URL.

## End-user install flow after merge

1. Download https://finaegis.github.io/defluff/manifest.xml
2. Outlook → **Get Add-ins** → **My add-ins** → **Custom Addins** → **Add from File** → pick the downloaded file
3. Click **De-Fluff** on any email

## Changes

- **Workflow** (\`.github/workflows/deploy-addin.yml\`): on push to main, builds \`apps/outlook-addin\` with base path \`/defluff/\`, generates the production manifest, deploys to GitHub Pages via \`actions/deploy-pages\`.
- **Vite config**: \`base\` is env-driven (\`DEFLUFF_ADDIN_BASE_PATH\`) so dev stays at \`/\` and CI uses \`/defluff/\`. \`basic-ssl\` now only loads in \`serve\` mode.
- **Manifest generator** (\`scripts/build-production-manifest.mjs\`): substitutes \`https://localhost:3000\` → \`DEFLUFF_ADDIN_BASE_URL\` to produce \`manifest.production.xml\`. Runs via \`pnpm build:manifest\`.
- **README rewrite**: end-user section first (hosted install), contributor section second (dev sideload).
- **.gitignore**: \`manifest.production.xml\` is a build artifact — source of truth is CI.

## One-time setup required on this repo

**Settings → Pages → Build and deployment → Source: GitHub Actions.** The workflow handles the rest via \`actions/configure-pages@v5\`. First successful run activates the Pages site.

## Not in this PR (tracked separately)

- #6 CORS smoke test — does the task pane at \`finaegis.github.io\` actually reach api.anthropic.com / api.openai.com / generativelanguage.googleapis.com? First real test happens once Pages is live.
- #7 AppSource submission — requires replacing the placeholder \`Id\` GUID and passing \`office-addin-manifest validate\`. Hosted manifest URL is a prerequisite, and this PR gives us that.