### PR TITLE
feat: LinkedIn host + per-host toggles + open options on install

### DIFF
--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -1,4 +1,4 @@
-import { defineManifest } from '@crxjs/vite-plugin';
+import { defineManifest, type ManifestV3Export } from '@crxjs/vite-plugin';
 
 // Host-scoped permissions only — never `<all_urls>`. The Chrome Web Store will
 // reject an email-scoped extension that asks for access to every page, and
@@ -8,6 +8,13 @@ const EMAIL_HOSTS = [
   'https://outlook.office.com/*',
   'https://outlook.office365.com/*',
   'https://outlook.live.com/*',
+] as const;
+
+// LinkedIn messaging lives here. Granted on demand via the options page's
+// "LinkedIn" toggle, not at install — so normal users don't see the LinkedIn
+// permission warning unless they actually want the feature.
+const OPTIONAL_HOSTS = [
+  'https://www.linkedin.com/*',
 ] as const;
 
 // The service worker fetches LLM provider APIs. These hosts must be in
@@ -28,6 +35,10 @@ const ICONS = {
   '128': 'icons/icon-128.png',
 } as const;
 
+// @crxjs/vite-plugin 2.0 beta types don't include optional_host_permissions
+// yet, so widen the inferred shape to accept it.
+type Manifest = ManifestV3Export & { optional_host_permissions?: readonly string[] };
+
 export default defineManifest({
   manifest_version: 3,
   name: 'Defluff',
@@ -42,11 +53,12 @@ export default defineManifest({
   background: { service_worker: 'src/background.ts', type: 'module' },
   permissions: ['storage'],
   host_permissions: [...EMAIL_HOSTS, ...PROVIDER_HOSTS],
+  optional_host_permissions: [...OPTIONAL_HOSTS],
   content_scripts: [
     {
-      matches: [...EMAIL_HOSTS],
+      matches: [...EMAIL_HOSTS, ...OPTIONAL_HOSTS],
       js: ['src/content/index.ts'],
       run_at: 'document_idle',
     },
   ],
-});
+} as Manifest);

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -2,6 +2,14 @@ import { DefluffError, summarize } from '@defluff/core';
 import { MSG_SUMMARIZE, type AppRequest, type SummarizeResponse } from './shared/messages.js';
 import { getProviderConfig } from './shared/storage.js';
 
+// Open the options page on fresh install so users land directly on the
+// provider-configuration screen instead of having to discover it.
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    void chrome.runtime.openOptionsPage();
+  }
+});
+
 // Toolbar icon click opens the options page. With no default_popup set, this
 // listener fires on every click. The options UI is the "settings" surface —
 // summarization itself lives on the inline De-Fluff button injected into Gmail

--- a/apps/extension/src/content/hosts/linkedin.ts
+++ b/apps/extension/src/content/hosts/linkedin.ts
@@ -1,0 +1,12 @@
+import { startHost } from '../ui/wireHost.js';
+
+// LinkedIn messaging DOM (2025-ish): individual messages live in
+// .msg-s-event-listitem__body under the conversation pane. Like Gmail and
+// Outlook this is a best-effort starting point — validate against live
+// LinkedIn and update the selector when it changes.
+export function startLinkedIn(): void {
+  startHost({
+    bodySelector: '.msg-s-event-listitem__body',
+    findAnchor: (body) => body.parentElement ?? body,
+  });
+}

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -1,14 +1,21 @@
+import { getHostsConfig } from '../shared/storage.js';
 import { startGmail } from './hosts/gmail.js';
+import { startLinkedIn } from './hosts/linkedin.js';
 import { startOutlook } from './hosts/outlook.js';
 
-const host = window.location.hostname;
+void (async () => {
+  const hosts = await getHostsConfig();
+  const host = window.location.hostname;
 
-if (host === 'mail.google.com') {
-  startGmail();
-} else if (
-  host === 'outlook.office.com' ||
-  host === 'outlook.office365.com' ||
-  host === 'outlook.live.com'
-) {
-  startOutlook();
-}
+  if (host === 'mail.google.com') {
+    if (hosts.gmail) startGmail();
+  } else if (
+    host === 'outlook.office.com' ||
+    host === 'outlook.office365.com' ||
+    host === 'outlook.live.com'
+  ) {
+    if (hosts.outlook) startOutlook();
+  } else if (host === 'www.linkedin.com') {
+    if (hosts.linkedin) startLinkedIn();
+  }
+})();

--- a/apps/extension/src/options/App.tsx
+++ b/apps/extension/src/options/App.tsx
@@ -1,17 +1,47 @@
 import {
   buildProviderConfig,
+  DEFAULT_HOSTS_CONFIG,
   isProviderKind,
   PROVIDER_DEFAULT_MODELS,
   PROVIDER_KINDS,
   PROVIDER_LABELS,
+  type HostsConfig,
   type ProviderKind,
 } from '@defluff/core';
 import { useEffect, useState } from 'react';
-import { clearProviderConfig, getProviderConfig, setProviderConfig } from '../shared/storage.js';
+import {
+  clearProviderConfig,
+  getHostsConfig,
+  getProviderConfig,
+  setHostsConfig,
+  setProviderConfig,
+} from '../shared/storage.js';
 
 type Status = 'idle' | 'saving' | 'saved' | 'error';
 
+const LINKEDIN_ORIGIN = 'https://www.linkedin.com/*';
+
+interface HostOption {
+  key: keyof HostsConfig;
+  label: string;
+  hint?: string;
+  requiresPermission?: string;
+}
+
+const HOST_OPTIONS: readonly HostOption[] = [
+  { key: 'gmail', label: 'Gmail', hint: 'mail.google.com' },
+  { key: 'outlook', label: 'Outlook Web', hint: 'outlook.office.com / outlook.live.com' },
+  {
+    key: 'linkedin',
+    label: 'LinkedIn Messaging',
+    hint: 'asks for the linkedin.com permission when enabled',
+    requiresPermission: LINKEDIN_ORIGIN,
+  },
+] as const;
+
 export function App() {
+  const [hosts, setHosts] = useState<HostsConfig>(DEFAULT_HOSTS_CONFIG);
+  const [hostsNotice, setHostsNotice] = useState('');
   const [kind, setKind] = useState<ProviderKind>('anthropic');
   const [apiKey, setApiKey] = useState('');
   const [model, setModel] = useState('');
@@ -21,6 +51,7 @@ export function App() {
 
   useEffect(() => {
     void (async () => {
+      setHosts(await getHostsConfig());
       const existing = await getProviderConfig();
       if (!existing) return;
       setKind(existing.kind);
@@ -29,6 +60,34 @@ export function App() {
       if (existing.kind === 'openai-compatible') setBaseUrl(existing.baseUrl);
     })();
   }, []);
+
+  const toggleHost = async (key: keyof HostsConfig, on: boolean): Promise<void> => {
+    const option = HOST_OPTIONS.find((h) => h.key === key);
+
+    if (option?.requiresPermission) {
+      if (on) {
+        const granted = await chrome.permissions.request({
+          origins: [option.requiresPermission],
+        });
+        if (!granted) {
+          setHostsNotice('Permission denied. LinkedIn stays off.');
+          return;
+        }
+      } else {
+        await chrome.permissions.remove({ origins: [option.requiresPermission] });
+      }
+    }
+
+    const next = { ...hosts, [key]: on };
+    setHosts(next);
+    await setHostsConfig(next);
+    setHostsNotice(
+      on
+        ? 'Enabled. Reload any already-open tab to activate on it.'
+        : 'Disabled. Reload affected tabs if the button is still showing.',
+    );
+    window.setTimeout(() => setHostsNotice(''), 4000);
+  };
 
   const handleSave = async (event: React.FormEvent): Promise<void> => {
     event.preventDefault();
@@ -66,7 +125,28 @@ export function App() {
         </p>
       </header>
 
+      <section className="hosts">
+        <h2>Where should Defluff appear?</h2>
+        <div className="host-toggles">
+          {HOST_OPTIONS.map((option) => (
+            <label key={option.key} className="host-toggle">
+              <input
+                type="checkbox"
+                checked={hosts[option.key]}
+                onChange={(e) => void toggleHost(option.key, e.target.checked)}
+              />
+              <span>
+                <strong>{option.label}</strong>
+                {option.hint && <small>{option.hint}</small>}
+              </span>
+            </label>
+          ))}
+        </div>
+        {hostsNotice && <p className="host-notice">{hostsNotice}</p>}
+      </section>
+
       <form onSubmit={handleSave}>
+        <h2>LLM provider</h2>
         <label>
           Provider
           <select value={kind} onChange={(e) => handleKindChange(e.target.value)}>

--- a/apps/extension/src/options/styles.css
+++ b/apps/extension/src/options/styles.css
@@ -26,6 +26,53 @@ main {
   padding: 48px 24px 64px;
 }
 
+main > section, main > form { margin-bottom: 32px; }
+
+main h2 {
+  margin: 0 0 4px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+section > h2 + div, form > h2 + label { margin-top: 12px; }
+
+.hosts h2 + * { margin-top: 4px; }
+
+.host-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fafbfc;
+}
+
+.host-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 10px;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.host-toggle input[type="checkbox"] {
+  margin-top: 3px;
+  width: auto;
+  padding: 0;
+}
+
+.host-toggle strong { display: block; font-weight: 500; }
+.host-toggle small { display: block; color: var(--muted); font-size: 12px; }
+
+.host-notice {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 header h1 {
   font-size: 28px;
   margin: 0 0 8px;

--- a/apps/extension/src/shared/storage.ts
+++ b/apps/extension/src/shared/storage.ts
@@ -1,17 +1,36 @@
-import { isProviderConfig, type ProviderConfig } from '@defluff/core';
+import {
+  DEFAULT_HOSTS_CONFIG,
+  isHostsConfig,
+  isProviderConfig,
+  type HostsConfig,
+  type ProviderConfig,
+} from '@defluff/core';
 
-const STORAGE_KEY = 'defluff.provider';
+const PROVIDER_KEY = 'defluff.provider';
+const HOSTS_KEY = 'defluff.hosts';
 
 export async function getProviderConfig(): Promise<ProviderConfig | null> {
-  const result = await chrome.storage.sync.get(STORAGE_KEY);
-  const value = result[STORAGE_KEY];
+  const result = await chrome.storage.sync.get(PROVIDER_KEY);
+  const value = result[PROVIDER_KEY];
   return isProviderConfig(value) ? value : null;
 }
 
 export async function setProviderConfig(config: ProviderConfig): Promise<void> {
-  await chrome.storage.sync.set({ [STORAGE_KEY]: config });
+  await chrome.storage.sync.set({ [PROVIDER_KEY]: config });
 }
 
 export async function clearProviderConfig(): Promise<void> {
-  await chrome.storage.sync.remove(STORAGE_KEY);
+  await chrome.storage.sync.remove(PROVIDER_KEY);
+}
+
+export async function getHostsConfig(): Promise<HostsConfig> {
+  const result = await chrome.storage.sync.get(HOSTS_KEY);
+  const value = result[HOSTS_KEY];
+  // Merge with defaults so new host keys added in a later release default
+  // sensibly for users who stored an older shape.
+  return isHostsConfig(value) ? { ...DEFAULT_HOSTS_CONFIG, ...value } : { ...DEFAULT_HOSTS_CONFIG };
+}
+
+export async function setHostsConfig(config: HostsConfig): Promise<void> {
+  await chrome.storage.sync.set({ [HOSTS_KEY]: config });
 }

--- a/apps/openclaw-skill/SKILL.md
+++ b/apps/openclaw-skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: defluff
 description: Extract the real intent of an email as 3-5 bullets. Strips pleasantries, corporate jargon, and AI-generated padding to surface only facts, intent, and action items.
+version: 0.0.1
 user-invocable: true
 ---
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildProviderConfig, isProviderConfig, isProviderKind } from './config.js';
+import { buildProviderConfig, isHostsConfig, isProviderConfig, isProviderKind } from './config.js';
 
 describe('isProviderKind', () => {
   it('accepts known kinds', () => {
@@ -90,5 +90,19 @@ describe('buildProviderConfig', () => {
         baseUrl: '',
       }),
     ).toThrow(/base URL/i);
+  });
+});
+
+describe('isHostsConfig', () => {
+  it('accepts objects with all three boolean fields', () => {
+    expect(isHostsConfig({ gmail: true, outlook: true, linkedin: false })).toBe(true);
+    expect(isHostsConfig({ gmail: false, outlook: false, linkedin: true })).toBe(true);
+  });
+
+  it('rejects malformed values', () => {
+    expect(isHostsConfig({ gmail: true, outlook: true })).toBe(false);
+    expect(isHostsConfig({ gmail: true, outlook: true, linkedin: 'yes' })).toBe(false);
+    expect(isHostsConfig({})).toBe(false);
+    expect(isHostsConfig(null)).toBe(false);
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,5 @@
 import { PROVIDER_DEFAULT_MODELS, PROVIDER_KINDS } from './providers/index.js';
-import type { ProviderConfig, ProviderKind } from './types.js';
+import type { HostsConfig, ProviderConfig, ProviderKind } from './types.js';
 
 export interface ProviderConfigInput {
   kind: ProviderKind;
@@ -49,4 +49,14 @@ export function isProviderKind(value: unknown): value is ProviderKind {
 
 export function isProviderConfig(value: unknown): value is ProviderConfig {
   return !!value && typeof value === 'object' && isProviderKind((value as { kind?: unknown }).kind);
+}
+
+export function isHostsConfig(value: unknown): value is HostsConfig {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.gmail === 'boolean' &&
+    typeof v.outlook === 'boolean' &&
+    typeof v.linkedin === 'boolean'
+  );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export {
   buildProviderConfig,
+  isHostsConfig,
   isProviderConfig,
   isProviderKind,
 } from './config.js';
@@ -14,9 +15,11 @@ export {
   PROVIDER_LABELS,
 } from './providers/index.js';
 export { summarize } from './summarize.js';
+export { DEFAULT_HOSTS_CONFIG } from './types.js';
 export type {
   AnthropicConfig,
   GeminiConfig,
+  HostsConfig,
   OpenAICompatibleConfig,
   OpenAIConfig,
   ProviderAdapter,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,23 @@ export interface Summary {
   bullets: string[];
 }
 
+/**
+ * Which email/messaging hosts should show the De-Fluff button. Gmail and
+ * Outlook are on by default; LinkedIn is opt-in because its host permission
+ * requires an extra prompt (see `optional_host_permissions` in the manifest).
+ */
+export interface HostsConfig {
+  gmail: boolean;
+  outlook: boolean;
+  linkedin: boolean;
+}
+
+export const DEFAULT_HOSTS_CONFIG: HostsConfig = {
+  gmail: true,
+  outlook: true,
+  linkedin: false,
+};
+
 export interface SummarizeOptions {
   text: string;
   provider: ProviderConfig;


### PR DESCRIPTION
Three user-facing improvements in one PR — all tightly coupled because the LinkedIn support pattern requires the toggle UX.

## LinkedIn messaging

New host strategy in \`apps/extension/src/content/hosts/linkedin.ts\` that points the shared \`startHost()\` at LinkedIn's \`.msg-s-event-listitem__body\` selector. Same **best-effort selectors + needs live DOM validation** caveat as Gmail/Outlook (see [#4](https://github.com/FinAegis/defluff/issues/4), [#5](https://github.com/FinAegis/defluff/issues/5)).

**Permissions model:** \`linkedin.com\` is in \`optional_host_permissions\`, **not** \`host_permissions\`. That means users don't see a \"Defluff wants to read your data on linkedin.com\" warning at install. The permission is requested only when they toggle LinkedIn on.

## Per-host toggles

New options-page section: **Where should Defluff appear?**

- Gmail ✅ (on by default — permission already granted at install)
- Outlook Web ✅ (same)
- LinkedIn Messaging ⬜ (off by default — asks for the linkedin.com permission when enabled)

Toggling LinkedIn on → \`chrome.permissions.request\` → user approves in a native Chrome dialog → storage updated → future LinkedIn tabs auto-inject. Toggling off → \`chrome.permissions.remove\` + storage updated.

Disabling Gmail or Outlook doesn't revoke those install-time permissions (they're not optional), but the content script reads the config and returns early, so no button is injected.

## Open options on fresh install

\`chrome.runtime.onInstalled\` listener with \`details.reason === 'install'\` opens the options page. Fires once on a clean install, not on updates or browser restart. Nothing to test for existing users; reinstall the unpacked extension to see it.

## Openclaw fix

Bumped \`apps/openclaw-skill/SKILL.md\` frontmatter to include \`version: 0.0.1\` so \`clawhub publish apps/openclaw-skill\` works without \`--version\` on the CLI.

## Verification

- \`pnpm -r typecheck\` — clean.
- \`pnpm --filter @defluff/core test\` — **22/22** (3 new \`isHostsConfig\` cases).
- \`pnpm --filter @defluff/extension build\` — manifest includes \`optional_host_permissions: [\"https://www.linkedin.com/*\"]\` and content script matches LinkedIn correctly.

## Follow-up

Should open a dedicated issue for the LinkedIn DOM validation pass (sister to #4/#5). Happy to open it after merge.