### PR TITLE
chore: pnpm skill:publish wrapper for clawhub (auto-reads version)

### DIFF
--- a/apps/openclaw-skill/README.md
+++ b/apps/openclaw-skill/README.md
@@ -14,12 +14,13 @@ mkdir -p ~/.openclaw/workspace/skills/defluff
 cp SKILL.md ~/.openclaw/workspace/skills/defluff/
 ```
 
-Or publish to ClawHub:
+Or publish to ClawHub from the repo root:
 
 ```bash
-# from this directory
-clawhub publish
+pnpm skill:publish
 ```
+
+This reads the `version:` field from `SKILL.md` frontmatter and invokes `clawhub publish` with the right flags. First time publishing? Run `clawhub login` once before. Bump the version in `SKILL.md` each release.
 
 See the [Openclaw skills docs](https://docs.openclaw.ai/tools/skills) for details on discovery and updates.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "icons": "node scripts/generate-icons.mjs"
+    "icons": "node scripts/generate-icons.mjs",
+    "skill:publish": "node scripts/publish-skill.mjs"
   },
   "devDependencies": {
     "sharp": "^0.34.5"

--- a/scripts/publish-skill.mjs
+++ b/scripts/publish-skill.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Wrapper around `clawhub publish` that reads the version out of the skill's
+// SKILL.md frontmatter instead of requiring it on the command line. Keeps
+// `apps/openclaw-skill/SKILL.md` as the single source of truth for the
+// published version.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const skillDir = join(here, '..', 'apps', 'openclaw-skill');
+const skillMd = readFileSync(join(skillDir, 'SKILL.md'), 'utf8');
+
+const frontmatter = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+const version = frontmatter?.[1].match(/^version:\s*(\S+)\s*$/m)?.[1];
+
+if (!version) {
+  console.error('No "version:" key found in apps/openclaw-skill/SKILL.md frontmatter.');
+  process.exit(1);
+}
+
+console.log(`Publishing apps/openclaw-skill at version ${version}`);
+execFileSync('clawhub', ['publish', skillDir, '--version', version], { stdio: 'inherit' });


### PR DESCRIPTION
The `clawhub` CLI doesn't pick up `version:` from SKILL.md frontmatter — it requires `--version` on its own command line. Easy to drift, and the error message (`--version must be valid semver`) isn't discoverable.

This PR adds `scripts/publish-skill.mjs` which parses the frontmatter version and shells out to `clawhub publish` with it. Single source of truth stays in `SKILL.md`; bump the version there and run:

```bash
pnpm skill:publish
```

Skill README updated to point at this command.