### PR TITLE
fix(skill:publish): read slug from SKILL.md name field

### DIFF
--- a/scripts/publish-skill.mjs
+++ b/scripts/publish-skill.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-// Wrapper around `clawhub publish` that reads the version out of the skill's
-// SKILL.md frontmatter instead of requiring it on the command line. Keeps
-// `apps/openclaw-skill/SKILL.md` as the single source of truth for the
-// published version.
+// Wrapper around `clawhub publish` that reads version + slug out of the skill's
+// SKILL.md frontmatter instead of requiring them on the command line. Keeps
+// `apps/openclaw-skill/SKILL.md` as the single source of truth for what gets
+// published.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -13,12 +13,32 @@ const skillDir = join(here, '..', 'apps', 'openclaw-skill');
 const skillMd = readFileSync(join(skillDir, 'SKILL.md'), 'utf8');
 
 const frontmatter = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-const version = frontmatter?.[1].match(/^version:\s*(\S+)\s*$/m)?.[1];
-
-if (!version) {
-  console.error('No "version:" key found in apps/openclaw-skill/SKILL.md frontmatter.');
+if (!frontmatter) {
+  console.error('No frontmatter block found in apps/openclaw-skill/SKILL.md.');
   process.exit(1);
 }
 
-console.log(`Publishing apps/openclaw-skill at version ${version}`);
-execFileSync('clawhub', ['publish', skillDir, '--version', version], { stdio: 'inherit' });
+const getField = (key) =>
+  frontmatter[1].match(new RegExp(`^${key}:\\s*(\\S+)\\s*$`, 'm'))?.[1];
+
+const version = getField('version');
+// The default slug would come from the folder name ("openclaw-skill"), which
+// is too generic — someone else already claimed it on ClawHub. We use the
+// `name:` field so the slug stays in sync with the skill's identity.
+const slug = getField('name');
+
+if (!version) {
+  console.error('No "version:" key in apps/openclaw-skill/SKILL.md frontmatter.');
+  process.exit(1);
+}
+if (!slug) {
+  console.error('No "name:" key in apps/openclaw-skill/SKILL.md frontmatter.');
+  process.exit(1);
+}
+
+console.log(`Publishing apps/openclaw-skill as "${slug}" at version ${version}`);
+execFileSync(
+  'clawhub',
+  ['publish', skillDir, '--slug', slug, '--version', version],
+  { stdio: 'inherit' },
+);


### PR DESCRIPTION
ClawHub defaults the slug to the skill directory name — `openclaw-skill` — which a different user already claimed, so `clawhub publish` returns `Slug is already taken`.

This PR has the script read the `name:` field from SKILL.md frontmatter (`defluff`) and pass it as `--slug`. Single source of truth; bump the frontmatter, the publish command stays in sync.

After merge: `pnpm skill:publish` works with no CLI flags.