### PR TITLE
fix(skill:publish): pass --name for ClawHub display name

### DIFF
--- a/apps/openclaw-skill/SKILL.md
+++ b/apps/openclaw-skill/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: defluff
+displayName: Defluff
 description: Extract the real intent of an email as 3-5 bullets. Strips pleasantries, corporate jargon, and AI-generated padding to surface only facts, intent, and action items.
-version: 0.0.1
+version: 0.0.2
 user-invocable: true
 ---
 

--- a/scripts/publish-skill.mjs
+++ b/scripts/publish-skill.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-// Wrapper around `clawhub publish` that reads version + slug out of the skill's
-// SKILL.md frontmatter instead of requiring them on the command line. Keeps
-// `apps/openclaw-skill/SKILL.md` as the single source of truth for what gets
-// published.
+// Wrapper around `clawhub publish` that reads version + slug + display name
+// out of the skill's SKILL.md frontmatter instead of requiring them on the
+// command line. Keeps `apps/openclaw-skill/SKILL.md` as the single source of
+// truth for what gets published.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -19,13 +19,18 @@ if (!frontmatter) {
 }
 
 const getField = (key) =>
-  frontmatter[1].match(new RegExp(`^${key}:\\s*(\\S+)\\s*$`, 'm'))?.[1];
+  frontmatter[1]
+    .match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]
+    ?.trim();
 
 const version = getField('version');
-// The default slug would come from the folder name ("openclaw-skill"), which
-// is too generic — someone else already claimed it on ClawHub. We use the
-// `name:` field so the slug stays in sync with the skill's identity.
+// Slug defaults to the lowercased skill identifier. Sourced from `name:` so
+// it never drifts from the folder / ClawHub URL.
 const slug = getField('name');
+// Display name shown on ClawHub. Falls back to a title-cased slug when the
+// `displayName:` field is omitted.
+const displayName =
+  getField('displayName') ?? (slug ? slug.charAt(0).toUpperCase() + slug.slice(1) : undefined);
 
 if (!version) {
   console.error('No "version:" key in apps/openclaw-skill/SKILL.md frontmatter.');
@@ -35,10 +40,14 @@ if (!slug) {
   console.error('No "name:" key in apps/openclaw-skill/SKILL.md frontmatter.');
   process.exit(1);
 }
+if (!displayName) {
+  console.error('Could not resolve a display name.');
+  process.exit(1);
+}
 
-console.log(`Publishing apps/openclaw-skill as "${slug}" at version ${version}`);
+console.log(`Publishing "${displayName}" (slug: ${slug}, version: ${version})`);
 execFileSync(
   'clawhub',
-  ['publish', skillDir, '--slug', slug, '--version', version],
+  ['publish', skillDir, '--slug', slug, '--name', displayName, '--version', version],
   { stdio: 'inherit' },
 );


### PR DESCRIPTION
ClawHub was falling back to a generic "Openclaw Skill" display name because `clawhub publish` needs `--name` separately from `--slug` and the script only passed the slug.

- SKILL.md gains `displayName: Defluff` and bumps to 0.0.2 (ClawHub rejects republishing the same version).
- Script reads `displayName:`, falls back to title-cased slug when missing.
- `getField` regex widened to support multi-word display names.

Already re-published `defluff@0.0.2` — listing at https://clawhub.ai/yozaz/defluff now shows "Defluff v0.0.2".