### PR TITLE
feat: Phase A polish — errors, a11y, dark mode, keyboard shortcut

### DIFF
--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -51,6 +51,15 @@ export default defineManifest({
   },
   options_ui: { page: 'src/options/index.html', open_in_tab: true },
   background: { service_worker: 'src/background.ts', type: 'module' },
+  commands: {
+    defluff_active: {
+      suggested_key: {
+        default: 'Ctrl+Shift+D',
+        mac: 'Command+Shift+D',
+      },
+      description: 'De-Fluff the email currently in view',
+    },
+  },
   permissions: ['storage'],
   host_permissions: [...EMAIL_HOSTS, ...PROVIDER_HOSTS],
   optional_host_permissions: [...OPTIONAL_HOSTS],

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,5 +1,11 @@
 import { DefluffError, summarize } from '@defluff/core';
-import { MSG_SUMMARIZE, type AppRequest, type SummarizeResponse } from './shared/messages.js';
+import {
+  MSG_OPEN_OPTIONS,
+  MSG_SUMMARIZE,
+  MSG_TRIGGER_ACTIVE,
+  type AppRequest,
+  type SummarizeResponse,
+} from './shared/messages.js';
 import { getProviderConfig } from './shared/storage.js';
 
 // Open the options page on fresh install so users land directly on the
@@ -18,12 +24,29 @@ chrome.action.onClicked.addListener(() => {
   void chrome.runtime.openOptionsPage();
 });
 
+// Keyboard shortcut (Ctrl/Cmd+Shift+D) triggers the in-view De-Fluff button
+// on the active tab. Content script finds the best target by proximity to
+// the viewport center.
+chrome.commands.onCommand.addListener(async (command, tab) => {
+  if (command !== 'defluff_active' || !tab?.id) return;
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: MSG_TRIGGER_ACTIVE });
+  } catch {
+    // Active tab has no content script (not Gmail / Outlook / LinkedIn) — no-op.
+  }
+});
+
 chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
   if (!isAppRequest(message)) return undefined;
 
   if (message.type === MSG_SUMMARIZE) {
     void handleSummarize(message.text).then(sendResponse);
     return true; // Chrome MV3 idiom: keep the channel open for an async response.
+  }
+
+  if (message.type === MSG_OPEN_OPTIONS) {
+    void chrome.runtime.openOptionsPage();
+    return undefined;
   }
 
   return undefined;

--- a/apps/extension/src/content/hosts/linkedin.ts
+++ b/apps/extension/src/content/hosts/linkedin.ts
@@ -4,9 +4,14 @@ import { startHost } from '../ui/wireHost.js';
 // .msg-s-event-listitem__body under the conversation pane. Like Gmail and
 // Outlook this is a best-effort starting point — validate against live
 // LinkedIn and update the selector when it changes.
+//
+// LinkedIn places the sender avatar as a sibling of the message content.
+// Prepending to the body's parent crowds the avatar; we append instead so
+// the button lands below the message, with breathing room.
 export function startLinkedIn(): void {
   startHost({
     bodySelector: '.msg-s-event-listitem__body',
     findAnchor: (body) => body.parentElement ?? body,
+    insertAs: 'last',
   });
 }

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -1,7 +1,9 @@
+import { MSG_TRIGGER_ACTIVE, type AppRequest } from '../shared/messages.js';
 import { getHostsConfig } from '../shared/storage.js';
 import { startGmail } from './hosts/gmail.js';
 import { startLinkedIn } from './hosts/linkedin.js';
 import { startOutlook } from './hosts/outlook.js';
+import { triggerClosestButton } from './ui/wireHost.js';
 
 void (async () => {
   const hosts = await getHostsConfig();
@@ -19,3 +21,16 @@ void (async () => {
     if (hosts.linkedin) startLinkedIn();
   }
 })();
+
+// Keyboard shortcut handler: background SW forwards the command; we find the
+// button closest to the viewport center and trigger it.
+chrome.runtime.onMessage.addListener((message: unknown) => {
+  if (!isAppRequest(message)) return;
+  if (message.type === MSG_TRIGGER_ACTIVE) {
+    triggerClosestButton();
+  }
+});
+
+function isAppRequest(value: unknown): value is AppRequest {
+  return !!value && typeof value === 'object' && 'type' in value;
+}

--- a/apps/extension/src/content/ui/button.ts
+++ b/apps/extension/src/content/ui/button.ts
@@ -3,12 +3,17 @@ import { CONTENT_CSS } from './styles.js';
 export interface ButtonController {
   element: HTMLElement;
   setBusy(busy: boolean): void;
+  focus(): void;
   remove(): void;
 }
 
 /**
  * Create a Shadow-DOM-hosted button. The host element is what you attach to the
  * page; the shadow tree owns the styles so Gmail/Outlook CSS can't bleed in.
+ *
+ * Busy state swaps the sparkle for a spinning glyph via CSS — no extra DOM.
+ * `aria-live` region inside the shadow announces state changes to screen
+ * readers without visual noise.
  */
 export function createButton(onClick: () => void): ButtonController {
   const host = document.createElement('span');
@@ -23,6 +28,7 @@ export function createButton(onClick: () => void): ButtonController {
   const button = document.createElement('button');
   button.className = 'df-button';
   button.type = 'button';
+  button.setAttribute('aria-label', 'De-Fluff this email');
 
   const icon = document.createElement('span');
   icon.className = 'df-icon';
@@ -35,18 +41,29 @@ export function createButton(onClick: () => void): ButtonController {
   button.appendChild(icon);
   button.appendChild(label);
 
+  const liveRegion = document.createElement('span');
+  liveRegion.className = 'df-sr-only';
+  liveRegion.setAttribute('aria-live', 'polite');
+
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
     onClick();
   });
+
   shadow.appendChild(button);
+  shadow.appendChild(liveRegion);
 
   return {
     element: host,
     setBusy(busy) {
       button.setAttribute('aria-busy', String(busy));
       button.disabled = busy;
+      icon.textContent = busy ? '↻' : '✦';
+      liveRegion.textContent = busy ? 'Summarizing…' : '';
+    },
+    focus() {
+      button.focus();
     },
     remove() {
       host.remove();

--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -2,12 +2,19 @@ import { CONTENT_CSS } from './styles.js';
 
 export interface PanelController {
   element: HTMLElement;
+  focus(): void;
   remove(): void;
+}
+
+export interface PanelError {
+  title: string;
+  explanation: string;
+  cta?: { label: string; onClick: () => void };
 }
 
 export interface PanelOptions {
   bullets?: string[];
-  error?: string;
+  error?: PanelError;
   onShowOriginal?: () => void;
   onDismiss?: () => void;
 }
@@ -22,16 +29,33 @@ export function createPanel(opts: PanelOptions): PanelController {
   shadow.appendChild(style);
 
   const panel = document.createElement('div');
-  panel.className = opts.error ? 'df-panel df-error' : 'df-panel';
+  const isError = !!opts.error;
+  panel.className = isError ? 'df-panel df-error' : 'df-panel';
+  panel.setAttribute('role', isError ? 'alert' : 'region');
+  panel.setAttribute('aria-label', isError ? 'Defluff error' : 'Email summary');
+  panel.tabIndex = -1;
 
   const heading = document.createElement('h3');
-  heading.textContent = opts.error ? 'Defluff error' : 'Defluffed summary';
+  if (isError && opts.error) {
+    const icon = document.createElement('span');
+    icon.className = 'df-error-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '⚠';
+    heading.appendChild(icon);
+    const text = document.createElement('span');
+    text.textContent = opts.error.title;
+    heading.appendChild(text);
+  } else {
+    heading.textContent = 'Defluffed summary';
+  }
   panel.appendChild(heading);
 
   if (opts.error) {
-    const p = document.createElement('p');
-    p.textContent = opts.error;
-    panel.appendChild(p);
+    if (opts.error.explanation) {
+      const p = document.createElement('p');
+      p.textContent = opts.error.explanation;
+      panel.appendChild(p);
+    }
   } else {
     const list = document.createElement('ul');
     for (const bullet of opts.bullets ?? []) {
@@ -44,7 +68,10 @@ export function createPanel(opts: PanelOptions): PanelController {
 
   const actions = document.createElement('div');
   actions.className = 'df-actions';
-  if (opts.onShowOriginal) {
+  if (opts.error?.cta) {
+    actions.appendChild(makeCta(opts.error.cta.label, opts.error.cta.onClick));
+  }
+  if (opts.onShowOriginal && !isError) {
     actions.appendChild(makeLink('Show original', opts.onShowOriginal));
   }
   if (opts.onDismiss) {
@@ -56,6 +83,9 @@ export function createPanel(opts: PanelOptions): PanelController {
 
   return {
     element: host,
+    focus() {
+      panel.focus();
+    },
     remove() {
       host.remove();
     },
@@ -65,6 +95,15 @@ export function createPanel(opts: PanelOptions): PanelController {
 function makeLink(label: string, onClick: () => void): HTMLButtonElement {
   const btn = document.createElement('button');
   btn.className = 'df-link';
+  btn.type = 'button';
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function makeCta(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'df-cta';
   btn.type = 'button';
   btn.textContent = label;
   btn.addEventListener('click', onClick);

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -1,11 +1,41 @@
 /**
  * Shared CSS for the in-page button and summary panel. Lives inside a Shadow
  * DOM host so host-page styles (Gmail's own CSS) can't leak in, and vice-versa.
+ *
+ * Respects `prefers-color-scheme: dark`. The host page's dark mode may not
+ * match OS preference (Gmail/Outlook/LinkedIn each have their own toggle) but
+ * matching OS is correct more often than hard-coding light.
  */
 export const CONTENT_CSS = `
 :host {
   all: initial;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  --df-bg: #ffffff;
+  --df-panel-bg: #f8faff;
+  --df-panel-border: #dadce0;
+  --df-fg: #202124;
+  --df-muted: #5f6368;
+  --df-accent: #1a73e8;
+  --df-accent-hover: #1558b0;
+  --df-error-bg: #fef7f7;
+  --df-error-accent: #d93025;
+  --df-shadow: 0 1px 2px rgba(60,64,67,.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  :host {
+    --df-bg: #202124;
+    --df-panel-bg: #2a2d31;
+    --df-panel-border: #3c4043;
+    --df-fg: #e8eaed;
+    --df-muted: #9aa0a6;
+    --df-accent: #8ab4f8;
+    --df-accent-hover: #aecbfa;
+    --df-error-bg: #2c1e1e;
+    --df-error-accent: #f28b82;
+    --df-shadow: 0 1px 2px rgba(0,0,0,.4);
+  }
 }
 
 .df-button {
@@ -13,60 +43,103 @@ export const CONTENT_CSS = `
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border: 1px solid #dadce0;
+  border: 1px solid var(--df-panel-border);
   border-radius: 18px;
-  background: #fff;
-  color: #3c4043;
+  background: var(--df-bg);
+  color: var(--df-fg);
   font-size: 13px;
   font-weight: 500;
   line-height: 1;
   cursor: pointer;
   transition: background 0.12s ease, box-shadow 0.12s ease;
 }
-.df-button:hover { background: #f8f9fa; box-shadow: 0 1px 2px rgba(60,64,67,.15); }
-.df-button:focus-visible { outline: 2px solid #1a73e8; outline-offset: 2px; }
-.df-button[aria-busy="true"] { opacity: 0.7; cursor: progress; }
+.df-button:hover { background: color-mix(in srgb, var(--df-accent) 6%, var(--df-bg)); box-shadow: var(--df-shadow); }
+.df-button:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 2px; }
+.df-button[aria-busy="true"] { cursor: progress; }
+.df-button[aria-busy="true"] .df-icon {
+  animation: df-spin 0.9s linear infinite;
+  display: inline-block;
+}
 .df-button .df-icon { font-size: 14px; line-height: 1; }
+
+@keyframes df-spin { to { transform: rotate(360deg); } }
 
 .df-panel {
   position: relative;
   margin: 12px 0;
   padding: 16px 18px;
-  border: 1px solid #dadce0;
-  border-left: 3px solid #1a73e8;
+  border: 1px solid var(--df-panel-border);
+  border-left: 3px solid var(--df-accent);
   border-radius: 6px;
-  background: #f8faff;
-  color: #202124;
+  background: var(--df-panel-bg);
+  color: var(--df-fg);
   font-size: 14px;
   line-height: 1.5;
-  box-shadow: 0 1px 2px rgba(60,64,67,.08);
+  box-shadow: var(--df-shadow);
 }
+.df-panel:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 1px; }
 .df-panel h3 {
   margin: 0 0 8px 0;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #5f6368;
+  color: var(--df-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 .df-panel ul { margin: 0; padding-left: 18px; }
 .df-panel li { margin-bottom: 4px; }
 .df-panel li:last-child { margin-bottom: 0; }
-.df-panel .df-actions {
+
+.df-actions {
   margin-top: 12px;
   display: flex;
-  gap: 8px;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
 }
-.df-panel .df-link {
+
+.df-link {
   background: none;
   border: none;
   padding: 0;
-  color: #1a73e8;
+  color: var(--df-accent);
   font-size: 13px;
   cursor: pointer;
   font-weight: 500;
+  line-height: 1.4;
 }
-.df-panel .df-link:hover { text-decoration: underline; }
-.df-panel.df-error { border-left-color: #d93025; background: #fef7f7; }
-.df-panel.df-error h3 { color: #d93025; }
+.df-link:hover { text-decoration: underline; color: var(--df-accent-hover); }
+.df-link:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 2px; border-radius: 2px; }
+
+.df-cta {
+  background: var(--df-accent);
+  color: var(--df-bg);
+  border: none;
+  padding: 6px 14px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.df-cta:hover { background: var(--df-accent-hover); }
+.df-cta:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 2px; }
+
+.df-panel.df-error { border-left-color: var(--df-error-accent); background: var(--df-error-bg); }
+.df-panel.df-error h3 { color: var(--df-error-accent); text-transform: none; letter-spacing: 0; font-size: 14px; font-weight: 600; }
+.df-panel.df-error p { margin: 4px 0 0; color: var(--df-fg); font-size: 13px; }
+.df-panel .df-error-icon { font-size: 14px; }
+
+/* Screen-reader-only live region */
+.df-sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
 `;

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -1,9 +1,13 @@
+import { toUserError } from '@defluff/core';
 import type { SummarizeResponse } from '../../shared/messages.js';
-import { MSG_SUMMARIZE } from '../../shared/messages.js';
-import { createButton } from './button.js';
-import { createPanel } from './panel.js';
+import { MSG_OPEN_OPTIONS, MSG_SUMMARIZE } from '../../shared/messages.js';
+import { createButton, type ButtonController } from './button.js';
+import { createPanel, type PanelError } from './panel.js';
 
 const MARKER = 'data-defluff-wired';
+
+/** Registry used by the keyboard shortcut to trigger the closest visible button. */
+const TRIGGERS = new WeakMap<HTMLElement, () => void>();
 
 export interface HostStrategy {
   /**
@@ -59,6 +63,40 @@ export function startHost(strategy: HostStrategy): () => void {
   return () => observer.disconnect();
 }
 
+/**
+ * Trigger the De-Fluff button closest to the viewport center. Returns true
+ * if a button was triggered. Called by the content-script message handler
+ * when the keyboard shortcut fires.
+ */
+export function triggerClosestButton(): boolean {
+  const hosts = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-defluff="button"]'),
+  );
+  if (hosts.length === 0) return false;
+
+  const viewportCenter = window.innerHeight / 2;
+  let best: HTMLElement | null = null;
+  let bestDistance = Infinity;
+
+  for (const host of hosts) {
+    const rect = host.getBoundingClientRect();
+    if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+    const center = (rect.top + rect.bottom) / 2;
+    const distance = Math.abs(center - viewportCenter);
+    if (distance < bestDistance) {
+      best = host;
+      bestDistance = distance;
+    }
+  }
+
+  const target = best ?? hosts[0] ?? null;
+  if (!target) return false;
+  const handler = TRIGGERS.get(target);
+  if (!handler) return false;
+  handler();
+  return true;
+}
+
 function schedule(cb: () => void): void {
   if (typeof requestIdleCallback === 'function') {
     requestIdleCallback(cb, { timeout: 500 });
@@ -68,11 +106,15 @@ function schedule(cb: () => void): void {
 }
 
 function wireTarget(body: HTMLElement, anchor: HTMLElement): void {
-  let activePanel: { remove: () => void } | null = null;
+  let activePanel: { remove: () => void; focus: () => void } | null = null;
   let originalDisplay = '';
+  let button: ButtonController;
 
-  const button = createButton(async () => {
-    if (activePanel) return;
+  const trigger = async (): Promise<void> => {
+    if (activePanel) {
+      activePanel.focus();
+      return;
+    }
     if (!body.isConnected) return;
     button.setBusy(true);
 
@@ -98,16 +140,41 @@ function wireTarget(body: HTMLElement, anchor: HTMLElement): void {
       body.style.display = originalDisplay;
       activePanel?.remove();
       activePanel = null;
+      button.focus();
     };
 
     const panel = createPanel({
-      ...(response.ok ? { bullets: response.bullets } : { error: response.error }),
+      ...(response.ok ? { bullets: response.bullets } : {}),
+      ...(response.ok ? {} : { error: buildErrorPayload(response, restore) }),
       ...(response.ok ? { onShowOriginal: restore } : {}),
       onDismiss: restore,
     });
     body.parentElement.insertBefore(panel.element, body);
+    panel.focus();
     activePanel = panel;
-  });
+  };
 
+  button = createButton(() => {
+    void trigger();
+  });
+  TRIGGERS.set(button.element, () => void trigger());
   anchor.insertBefore(button.element, anchor.firstChild);
+}
+
+function buildErrorPayload(
+  response: { ok: false; error: string; code?: Parameters<typeof toUserError>[0] },
+  restore: () => void,
+): PanelError {
+  const userError = toUserError(response.code, response.error);
+  const base: PanelError = { title: userError.title, explanation: userError.explanation };
+  if (userError.action === 'configure') {
+    base.cta = {
+      label: 'Open settings',
+      onClick: () => {
+        void chrome.runtime.sendMessage({ type: MSG_OPEN_OPTIONS });
+        restore();
+      },
+    };
+  }
+  return base;
 }

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -16,10 +16,19 @@ export interface HostStrategy {
    */
   bodySelector: string;
   /**
-   * Where should the button be injected for a given body? The button is
-   * prepended (`insertBefore(..., anchor.firstChild)`) into this anchor.
+   * Where should the button be injected for a given body? Combined with
+   * `insertAs` below to decide whether the button prepends or appends inside
+   * this anchor.
    */
   findAnchor(body: HTMLElement): HTMLElement;
+  /**
+   * Insert position inside the anchor: 'first' (prepend) or 'last' (append).
+   * Default is 'first', which works for Gmail and Outlook where the anchor
+   * is the body's parent and we want the button at the top. LinkedIn places
+   * the avatar next to the body, so LinkedIn uses 'last' to land the button
+   * below the message, away from the profile picture.
+   */
+  insertAs?: 'first' | 'last';
 }
 
 /**
@@ -42,7 +51,7 @@ export function startHost(strategy: HostStrategy): () => void {
     for (const body of bodies) {
       body.setAttribute(MARKER, 'true');
       const anchor = strategy.findAnchor(body);
-      wireTarget(body, anchor);
+      wireTarget(body, anchor, strategy.insertAs ?? 'first');
     }
   };
 
@@ -105,7 +114,11 @@ function schedule(cb: () => void): void {
   }
 }
 
-function wireTarget(body: HTMLElement, anchor: HTMLElement): void {
+function wireTarget(
+  body: HTMLElement,
+  anchor: HTMLElement,
+  insertAs: 'first' | 'last',
+): void {
   let activePanel: { remove: () => void; focus: () => void } | null = null;
   let originalDisplay = '';
   let button: ButtonController;
@@ -158,7 +171,11 @@ function wireTarget(body: HTMLElement, anchor: HTMLElement): void {
     void trigger();
   });
   TRIGGERS.set(button.element, () => void trigger());
-  anchor.insertBefore(button.element, anchor.firstChild);
+  if (insertAs === 'last') {
+    anchor.appendChild(button.element);
+  } else {
+    anchor.insertBefore(button.element, anchor.firstChild);
+  }
 }
 
 function buildErrorPayload(

--- a/apps/extension/src/options/styles.css
+++ b/apps/extension/src/options/styles.css
@@ -7,6 +7,23 @@
   --accent-hover: #1558b0;
   --ok: #188038;
   --err: #d93025;
+  --panel-bg: #fafbfc;
+  --code-bg: #f1f3f4;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #202124;
+    --fg: #e8eaed;
+    --muted: #9aa0a6;
+    --border: #3c4043;
+    --accent: #8ab4f8;
+    --accent-hover: #aecbfa;
+    --ok: #81c995;
+    --err: #f28b82;
+    --panel-bg: #292a2d;
+    --code-bg: #2a2d31;
+  }
 }
 
 * { box-sizing: border-box; }
@@ -46,7 +63,7 @@ section > h2 + div, form > h2 + label { margin-top: 12px; }
   padding: 14px 16px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #fafbfc;
+  background: var(--panel-bg);
 }
 
 .host-toggle {
@@ -130,7 +147,7 @@ button.secondary {
   color: var(--muted);
   border: 1px solid var(--border);
 }
-button.secondary:hover { background: #f1f3f4; }
+button.secondary:hover { background: var(--panel-bg); }
 
 .ok { color: var(--ok); font-weight: 500; }
 .err { color: var(--err); font-weight: 500; }
@@ -144,7 +161,7 @@ footer {
 }
 
 code {
-  background: #f1f3f4;
+  background: var(--code-bg);
   padding: 1px 6px;
   border-radius: 3px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/apps/extension/src/shared/messages.ts
+++ b/apps/extension/src/shared/messages.ts
@@ -1,13 +1,23 @@
 import type { DefluffErrorCode } from '@defluff/core';
 
 export const MSG_SUMMARIZE = 'summarize' as const;
+export const MSG_TRIGGER_ACTIVE = 'trigger_active' as const;
+export const MSG_OPEN_OPTIONS = 'open_options' as const;
 
 export interface SummarizeRequest {
   type: typeof MSG_SUMMARIZE;
   text: string;
 }
 
-export type AppRequest = SummarizeRequest;
+export interface TriggerActiveRequest {
+  type: typeof MSG_TRIGGER_ACTIVE;
+}
+
+export interface OpenOptionsRequest {
+  type: typeof MSG_OPEN_OPTIONS;
+}
+
+export type AppRequest = SummarizeRequest | TriggerActiveRequest | OpenOptionsRequest;
 
 export type SummarizeResponse =
   | { ok: true; bullets: string[] }

--- a/apps/outlook-addin/src/taskpane/main.ts
+++ b/apps/outlook-addin/src/taskpane/main.ts
@@ -3,6 +3,7 @@ import {
   DefluffError,
   isProviderKind,
   PROVIDER_DEFAULT_MODELS,
+  toUserError,
   type ProviderConfig,
   type ProviderKind,
   summarize,
@@ -129,14 +130,33 @@ function renderBullets(bullets: string[]): void {
 }
 
 function renderError(err: unknown): void {
-  const message =
+  const userError =
     err instanceof DefluffError
-      ? `${err.code}: ${err.message}`
-      : err instanceof Error
-        ? err.message
-        : 'Unknown error';
+      ? toUserError(err.code, err.message)
+      : toUserError(undefined, err instanceof Error ? err.message : 'Unknown error');
+
   const pane = byId('error');
-  pane.textContent = message;
+  pane.replaceChildren();
+
+  const heading = document.createElement('strong');
+  heading.textContent = userError.title;
+  pane.appendChild(heading);
+
+  if (userError.explanation) {
+    const p = document.createElement('p');
+    p.textContent = userError.explanation;
+    pane.appendChild(p);
+  }
+
+  if (userError.action === 'configure') {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'secondary';
+    btn.textContent = 'Change provider';
+    btn.addEventListener('click', () => showConfig(getProviderConfig()));
+    pane.appendChild(btn);
+  }
+
   pane.hidden = false;
 }
 

--- a/apps/outlook-addin/src/taskpane/styles.css
+++ b/apps/outlook-addin/src/taskpane/styles.css
@@ -8,6 +8,22 @@
   --ok: #107c10;
   --err: #a4262c;
   --panel: #f3f2f1;
+  --err-bg: #fde7e9;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1f1f1f;
+    --fg: #e6e6e6;
+    --muted: #a6a6a6;
+    --border: #3a3a3a;
+    --accent: #60cdff;
+    --accent-hover: #9adcff;
+    --ok: #6ccb5f;
+    --err: #f28b82;
+    --panel: #2a2a2a;
+    --err-bg: #3a1e21;
+  }
 }
 
 * { box-sizing: border-box; }
@@ -109,12 +125,18 @@ button.link:hover { text-decoration: underline; background: none; color: var(--a
 
 .error {
   margin-top: 8px;
-  padding: 12px 14px;
-  background: #fde7e9;
+  padding: 14px 16px;
+  background: var(--err-bg);
   border-left: 3px solid var(--err);
-  color: var(--err);
+  color: var(--fg);
   font-size: 13px;
   border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
+.error strong { color: var(--err); font-size: 14px; }
+.error p { margin: 0; }
+.error button { align-self: flex-start; margin-top: 4px; }
 
 .settings-link { margin-top: 14px; font-size: 13px; color: var(--muted); }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,8 @@ export {
   PROVIDER_LABELS,
 } from './providers/index.js';
 export { summarize } from './summarize.js';
+export { toUserError } from './user-errors.js';
+export type { UserError, UserErrorAction } from './user-errors.js';
 export { DEFAULT_HOSTS_CONFIG } from './types.js';
 export type {
   AnthropicConfig,

--- a/packages/core/src/user-errors.test.ts
+++ b/packages/core/src/user-errors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { toUserError } from './user-errors.js';
+
+describe('toUserError', () => {
+  it('maps auth to a configure action', () => {
+    expect(toUserError('auth')).toMatchObject({ action: 'configure' });
+  });
+
+  it('maps rate_limit to a retry action', () => {
+    expect(toUserError('rate_limit')).toMatchObject({ action: 'retry' });
+  });
+
+  it('maps unknown_provider to a configure action with setup copy', () => {
+    const err = toUserError('unknown_provider');
+    expect(err.action).toBe('configure');
+    expect(err.explanation).toMatch(/settings/i);
+  });
+
+  it('falls back for unknown codes', () => {
+    const err = toUserError(undefined);
+    expect(err.title).toBe('Something went wrong');
+  });
+
+  it('honors an explicit fallback message', () => {
+    const err = toUserError(undefined, 'Custom fallback');
+    expect(err.explanation).toBe('Custom fallback');
+  });
+});

--- a/packages/core/src/user-errors.ts
+++ b/packages/core/src/user-errors.ts
@@ -1,0 +1,70 @@
+import type { DefluffErrorCode } from './errors.js';
+
+export type UserErrorAction = 'configure' | 'retry' | 'none';
+
+export interface UserError {
+  /** Short human-readable headline. First thing the user reads. */
+  title: string;
+  /** One-sentence explanation of what went wrong and what to do. */
+  explanation: string;
+  /** Hints to the UI what kind of CTA to render. */
+  action: UserErrorAction;
+}
+
+/**
+ * Map internal DefluffError codes to user-facing copy. Clients translate the
+ * `action` hint into a concrete button (e.g. "Open settings" for
+ * `configure`, "Try again" for `retry`). The fallback message is only used
+ * when an unknown code comes through — we try to surface something useful
+ * even then.
+ */
+export function toUserError(
+  code: DefluffErrorCode | undefined,
+  fallback = 'Something went wrong. Try again.',
+): UserError {
+  if (code && code in MESSAGES) return MESSAGES[code];
+  return { title: 'Something went wrong', explanation: fallback, action: 'retry' };
+}
+
+const MESSAGES: Record<DefluffErrorCode, UserError> = {
+  network: {
+    title: "Couldn't reach the provider",
+    explanation: 'Check your internet connection, then try again.',
+    action: 'retry',
+  },
+  auth: {
+    title: "Your API key isn't working",
+    explanation: 'It may have been revoked or run out of quota. Update it in settings.',
+    action: 'configure',
+  },
+  rate_limit: {
+    title: 'Too many requests right now',
+    explanation: 'Your provider is throttling. Wait a minute and try again.',
+    action: 'retry',
+  },
+  bad_request: {
+    title: 'The provider rejected the request',
+    explanation: 'The model name might be wrong. Check settings.',
+    action: 'configure',
+  },
+  server: {
+    title: 'The provider had a server error',
+    explanation: 'Usually temporary. Try again in a moment.',
+    action: 'retry',
+  },
+  aborted: {
+    title: 'Request cancelled',
+    explanation: '',
+    action: 'none',
+  },
+  no_bullets: {
+    title: "Couldn't find a summary to extract",
+    explanation: 'The model returned an unusual response. Try a different model.',
+    action: 'configure',
+  },
+  unknown_provider: {
+    title: 'No provider configured',
+    explanation: 'Open settings to pick an LLM provider and paste your key.',
+    action: 'configure',
+  },
+};


### PR DESCRIPTION
Four user-facing polish items from the UX audit bundled into one PR — same code surfaces, so splitting would churn more than it'd clarify.

## 1. Human-friendly errors

Raw `DefluffErrorCode` strings used to leak to the UI ("auth: Invalid API key"). New `toUserError()` in `@defluff/core` maps each code to a `{ title, explanation, action }` triple where `action` hints at the CTA the UI should render.

Result:
- `auth` / `bad_request` / `no_bullets` / `unknown_provider` → **"Open settings"** button (extension) or **"Change provider"** button (Outlook).
- `network` / `rate_limit` / `server` → retry-class with a clear explanation, no CTA needed.
- `aborted` → silent.

5 new vitest cases for the mapping. Suite at 27/27.

## 2. Accessibility pass

- In-page button: explicit `aria-label`, shadow-DOM `aria-live` region announces "Summarizing…" to screen readers, spinner glyph on busy.
- In-page panel: `role="region"` with `aria-label` for success, `role="alert"` for errors, tabindex + focus moved to panel on open, focus returned to the button on dismiss.
- Error title uses a ⚠ icon + text (not color-alone).
- Focus-visible outlines on CTA and dismiss buttons.

## 3. Dark mode

`@media (prefers-color-scheme: dark)` variants for:
- Shadow-DOM content CSS (button + panel)
- Extension options page
- Outlook task pane

CSS custom properties so the dark palette overrides in one block.

## 4. Keyboard shortcut: `Cmd+Shift+D` / `Ctrl+Shift+D`

Manifest `commands` entry → background SW forwards to active tab → content script picks the De-Fluff button closest to the viewport center (multi-message Gmail threads) and triggers it. Falls through silently on non-supported hosts.

## Verification

- `pnpm -r typecheck` clean
- 27/27 tests (5 new `toUserError` cases)
- Both clients build
- Extension content-script bundle grew from ~5kB → ~10kB from the richer shadow-DOM CSS; still tiny

## Not in this PR (Phase B and beyond)

- Onboarding wizard with "Test connection" button
- Bullet-category structure in the summary (⚡ actions / ❓ questions / 📋 facts)
- Local usage stats in the options page
- Response cache keyed on email hash