### PR TITLE
feat: reverse the AI — prompt reversal + verdict + noise/scam detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ TypeScript end-to-end. Vite for the extension. pnpm for the workspace.
 - **Zero-retention is structural, not policy.** There is no server to persist on. If you find yourself adding one, stop and raise it — it's an architecture change, not an implementation detail.
 - **Extension permissions must be host-specific** (`mail.google.com`, `outlook.office.com`). Never request `<all_urls>` — it fails Chrome Web Store review.
 - **Provider adapters must be pluggable.** No hard-coded provider anywhere outside `packages/core/providers/`. The extraction prompt is fixed; the provider is not.
-- **Extraction prompt is load-bearing.** The exact wording is specified in `requirements.md` §4.4 ("You are an extraction tool…"). Preserve its restrictive framing — loosening it reintroduces the fluff the product exists to remove.
+- **Extraction prompt is load-bearing.** The authoritative wording lives in `packages/core/src/prompt.ts`; `requirements.md` §4.4 summarizes it. It instructs the model to produce three things in order: the `Prompt:` reversal (soul of the product), the `Verdict:` classification (ACTIONABLE / RESPONSE-NEEDED / FYI / NOISE with scam-pattern naming in the reason), and 3–5 bullets of specifics. Preserve the restrictive framing — loosening reintroduces the fluff the product exists to remove. Any change updates both files in the same commit.
 - **Latency-optimized models by default** (Claude Haiku, GPT-4o mini, Gemini Flash). This is extraction, not creative writing.
 
 ## Coding conventions

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -63,8 +63,8 @@ async function handleSummarize(text: string): Promise<SummarizeResponse> {
   }
 
   try {
-    const { bullets } = await summarize({ text, provider });
-    return { ok: true, bullets };
+    const summary = await summarize({ text, provider });
+    return { ok: true, summary };
   } catch (err) {
     if (err instanceof DefluffError) {
       return { ok: false, error: err.message, code: err.code };

--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -1,3 +1,4 @@
+import type { Summary, Verdict } from '@defluff/core';
 import { CONTENT_CSS } from './styles.js';
 
 export interface PanelController {
@@ -13,11 +14,25 @@ export interface PanelError {
 }
 
 export interface PanelOptions {
-  bullets?: string[];
+  summary?: Summary;
   error?: PanelError;
   onShowOriginal?: () => void;
   onDismiss?: () => void;
 }
+
+const VERDICT_LABELS: Record<Verdict, string> = {
+  actionable: 'Actionable',
+  'response-needed': 'Response needed',
+  fyi: 'FYI',
+  noise: 'Noise',
+};
+
+const VERDICT_ICONS: Record<Verdict, string> = {
+  actionable: '⚡',
+  'response-needed': '💬',
+  fyi: 'ℹ',
+  noise: '🗑',
+};
 
 export function createPanel(opts: PanelOptions): PanelController {
   const host = document.createElement('div');
@@ -34,36 +49,14 @@ export function createPanel(opts: PanelOptions): PanelController {
   panel.setAttribute('role', isError ? 'alert' : 'region');
   panel.setAttribute('aria-label', isError ? 'Defluff error' : 'Email summary');
   panel.tabIndex = -1;
-
-  const heading = document.createElement('h3');
-  if (isError && opts.error) {
-    const icon = document.createElement('span');
-    icon.className = 'df-error-icon';
-    icon.setAttribute('aria-hidden', 'true');
-    icon.textContent = '⚠';
-    heading.appendChild(icon);
-    const text = document.createElement('span');
-    text.textContent = opts.error.title;
-    heading.appendChild(text);
-  } else {
-    heading.textContent = 'Defluffed summary';
+  if (!isError && opts.summary?.verdict) {
+    panel.dataset.verdict = opts.summary.verdict;
   }
-  panel.appendChild(heading);
 
-  if (opts.error) {
-    if (opts.error.explanation) {
-      const p = document.createElement('p');
-      p.textContent = opts.error.explanation;
-      panel.appendChild(p);
-    }
-  } else {
-    const list = document.createElement('ul');
-    for (const bullet of opts.bullets ?? []) {
-      const li = document.createElement('li');
-      li.textContent = bullet;
-      list.appendChild(li);
-    }
-    panel.appendChild(list);
+  if (isError && opts.error) {
+    renderError(panel, opts.error);
+  } else if (opts.summary) {
+    renderSummary(panel, opts.summary);
   }
 
   const actions = document.createElement('div');
@@ -90,6 +83,99 @@ export function createPanel(opts: PanelOptions): PanelController {
       host.remove();
     },
   };
+}
+
+function renderError(panel: HTMLElement, error: PanelError): void {
+  const heading = document.createElement('h3');
+  const icon = document.createElement('span');
+  icon.className = 'df-error-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '⚠';
+  heading.appendChild(icon);
+  const text = document.createElement('span');
+  text.textContent = error.title;
+  heading.appendChild(text);
+  panel.appendChild(heading);
+
+  if (error.explanation) {
+    const p = document.createElement('p');
+    p.textContent = error.explanation;
+    panel.appendChild(p);
+  }
+}
+
+function renderSummary(panel: HTMLElement, summary: Summary): void {
+  if (summary.reversedPrompt) {
+    panel.appendChild(buildPromptBlock(summary.reversedPrompt));
+  }
+
+  if (summary.verdict) {
+    panel.appendChild(buildVerdictRow(summary.verdict, summary.verdictReason));
+  }
+
+  if (summary.bullets.length > 0) {
+    const sectionLabel = document.createElement('p');
+    sectionLabel.className = 'df-section-label';
+    sectionLabel.textContent = 'Specifics';
+    panel.appendChild(sectionLabel);
+
+    const list = document.createElement('ul');
+    for (const bullet of summary.bullets) {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    }
+    panel.appendChild(list);
+  }
+}
+
+function buildPromptBlock(reversedPrompt: string): HTMLElement {
+  const block = document.createElement('section');
+  block.className = 'df-prompt';
+
+  const label = document.createElement('p');
+  label.className = 'df-prompt-label';
+  const icon = document.createElement('span');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '💭';
+  const labelText = document.createElement('span');
+  labelText.textContent = 'They probably asked an AI';
+  label.appendChild(icon);
+  label.appendChild(labelText);
+  block.appendChild(label);
+
+  const text = document.createElement('p');
+  text.className = 'df-prompt-text';
+  text.textContent = `“${reversedPrompt}”`;
+  block.appendChild(text);
+
+  return block;
+}
+
+function buildVerdictRow(verdict: Verdict, reason?: string): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'df-verdict';
+  row.dataset.verdict = verdict;
+
+  const icon = document.createElement('span');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = VERDICT_ICONS[verdict];
+
+  const label = document.createElement('span');
+  label.className = 'df-verdict-label';
+  label.textContent = VERDICT_LABELS[verdict];
+
+  row.appendChild(icon);
+  row.appendChild(label);
+
+  if (reason) {
+    const reasonSpan = document.createElement('span');
+    reasonSpan.className = 'df-verdict-reason';
+    reasonSpan.textContent = reason;
+    row.appendChild(reasonSpan);
+  }
+
+  return row;
 }
 
 function makeLink(label: string, onClick: () => void): HTMLButtonElement {

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -18,9 +18,18 @@ export const CONTENT_CSS = `
   --df-muted: #5f6368;
   --df-accent: #1a73e8;
   --df-accent-hover: #1558b0;
+
   --df-error-bg: #fef7f7;
   --df-error-accent: #d93025;
+
+  --df-verdict-actionable: #d93025;
+  --df-verdict-response: #1a73e8;
+  --df-verdict-fyi: #5f6368;
+  --df-verdict-noise: #8a8d91;
+
   --df-shadow: 0 1px 2px rgba(60,64,67,.15);
+  --df-prompt-bg: #eef4ff;
+  --df-prompt-accent: #1a73e8;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -32,9 +41,18 @@ export const CONTENT_CSS = `
     --df-muted: #9aa0a6;
     --df-accent: #8ab4f8;
     --df-accent-hover: #aecbfa;
+
     --df-error-bg: #2c1e1e;
     --df-error-accent: #f28b82;
+
+    --df-verdict-actionable: #f28b82;
+    --df-verdict-response: #8ab4f8;
+    --df-verdict-fyi: #9aa0a6;
+    --df-verdict-noise: #6b6e73;
+
     --df-shadow: 0 1px 2px rgba(0,0,0,.4);
+    --df-prompt-bg: #2a2f36;
+    --df-prompt-accent: #8ab4f8;
   }
 }
 
@@ -61,7 +79,6 @@ export const CONTENT_CSS = `
   display: inline-block;
 }
 .df-button .df-icon { font-size: 14px; line-height: 1; }
-
 @keyframes df-spin { to { transform: rotate(360deg); } }
 
 .df-panel {
@@ -78,20 +95,76 @@ export const CONTENT_CSS = `
   box-shadow: var(--df-shadow);
 }
 .df-panel:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 1px; }
-.df-panel h3 {
-  margin: 0 0 8px 0;
-  font-size: 12px;
+
+/* Reversed prompt block — the emotional payoff of the product */
+.df-prompt {
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  background: var(--df-prompt-bg);
+  border-left: 2px solid var(--df-prompt-accent);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.df-prompt-label {
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--df-muted);
+  margin: 0;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
+.df-prompt-text {
+  margin: 0;
+  font-style: italic;
+  font-size: 14px;
+  color: var(--df-fg);
+}
+
+/* Verdict row — icon + label + reason */
+.df-verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+.df-verdict[data-verdict="actionable"] { color: var(--df-verdict-actionable); }
+.df-verdict[data-verdict="response-needed"] { color: var(--df-verdict-response); }
+.df-verdict[data-verdict="fyi"] { color: var(--df-verdict-fyi); }
+.df-verdict[data-verdict="noise"] { color: var(--df-verdict-noise); }
+.df-verdict-label {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.df-verdict-reason {
+  color: var(--df-fg);
+  font-weight: 400;
+  font-style: italic;
+}
+
+.df-section-label {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--df-muted);
+}
+
 .df-panel ul { margin: 0; padding-left: 18px; }
 .df-panel li { margin-bottom: 4px; }
 .df-panel li:last-child { margin-bottom: 0; }
+
+/* De-emphasize bullets when verdict is noise — the reader mostly cares about the verdict */
+.df-panel[data-verdict="noise"] ul { opacity: 0.65; }
 
 .df-actions {
   margin-top: 12px;
@@ -128,7 +201,7 @@ export const CONTENT_CSS = `
 .df-cta:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 2px; }
 
 .df-panel.df-error { border-left-color: var(--df-error-accent); background: var(--df-error-bg); }
-.df-panel.df-error h3 { color: var(--df-error-accent); text-transform: none; letter-spacing: 0; font-size: 14px; font-weight: 600; }
+.df-panel.df-error h3 { color: var(--df-error-accent); text-transform: none; letter-spacing: 0; font-size: 14px; font-weight: 600; margin: 0 0 4px; display: flex; align-items: center; gap: 6px; }
 .df-panel.df-error p { margin: 4px 0 0; color: var(--df-fg); font-size: 13px; }
 .df-panel .df-error-icon { font-size: 14px; }
 

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -157,7 +157,7 @@ function wireTarget(
     };
 
     const panel = createPanel({
-      ...(response.ok ? { bullets: response.bullets } : {}),
+      ...(response.ok ? { summary: response.summary } : {}),
       ...(response.ok ? {} : { error: buildErrorPayload(response, restore) }),
       ...(response.ok ? { onShowOriginal: restore } : {}),
       onDismiss: restore,

--- a/apps/extension/src/shared/messages.ts
+++ b/apps/extension/src/shared/messages.ts
@@ -1,4 +1,4 @@
-import type { DefluffErrorCode } from '@defluff/core';
+import type { DefluffErrorCode, Summary } from '@defluff/core';
 
 export const MSG_SUMMARIZE = 'summarize' as const;
 export const MSG_TRIGGER_ACTIVE = 'trigger_active' as const;
@@ -20,5 +20,5 @@ export interface OpenOptionsRequest {
 export type AppRequest = SummarizeRequest | TriggerActiveRequest | OpenOptionsRequest;
 
 export type SummarizeResponse =
-  | { ok: true; bullets: string[] }
+  | { ok: true; summary: Summary }
   | { ok: false; error: string; code?: DefluffErrorCode };

--- a/apps/openclaw-skill/SKILL.md
+++ b/apps/openclaw-skill/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: defluff
 displayName: Defluff
-description: Extract the real intent of email content — single messages, threads, or a triage batch. Strips pleasantries, corporate jargon, and AI-generated padding, surfacing only facts, questions, and action items.
-version: 0.0.3
+description: Reverse the AI in corporate email. Guess the prompt the sender probably gave an LLM, classify the email, and extract the actual intent. Handles single messages, threads, and batches, with noise/scam detection.
+version: 0.0.4
 user-invocable: true
 ---
 
 # defluff
 
-Use this skill when the user pastes email content and wants the point — one message, a thread, or a batch of unrelated emails — not a polite summary.
+Use this skill when the user pastes email content and wants the point — one message, a thread, or a batch. Defluff **reverses the AI**: it guesses what prompt the sender probably gave an LLM to generate this email, classifies the email's urgency, and extracts the specifics.
 
 ## When to trigger
 
@@ -18,98 +18,105 @@ Use this skill when the user pastes email content and wants the point — one me
 
 ## Core rule
 
-You are an **extraction tool**. Strip all filler. Output only facts, intent, questions, and action items. Never add conversational padding of your own. Never write "Here's what I found", "In summary", "I hope this helps".
+You are an **AI-reversal tool**. Many corporate and outreach emails are padded by LLMs. For every email, do two things in order:
 
-## Priority order within bullets
+1. Guess what prompt the sender probably gave an AI to generate it.
+2. Extract the real intent as a short bullet list.
 
-When multiple kinds of content are present, surface them in this order:
+Never add conversational padding of your own. Never write "Here's what I found", "In summary", "I hope this helps".
 
-1. **Action items or deadlines** the user is expected to do
-2. **Direct questions** that require a response
-3. **Key facts** — numbers, dates, names, decisions, amounts (preserve verbatim)
-4. **Underlying intent** only if it's implicit rather than stated
+## Output format — single email
 
-Cut anything vague or paraphrased.
-
----
-
-## Modes
-
-### 1. Single email
-
-Output **3–5 bullets**. No header, no preamble.
-
-If the email has no substantive content (pleasantries only, or marketing, or an auto-reply), output exactly one bullet:
-
-- `No substantive content; [social | promotional | automated | out-of-office].`
-
-### 2. Thread (multiple messages in one input, same conversation)
-
-For each message, emit a bold header with sender + timestamp when available, then 1–3 bullets.
-
-After the per-message bullets, emit a consolidated **Actions** section listing every action item across the thread, each attributed to the person who owes it.
-
-Format:
+Three lines (two required plus bullets):
 
 ```
-**Alice — Tue 10:14**
-- Budget capped at $50k for Q3
+Prompt: "[short imperative the sender probably gave an AI, in quotes]"
+Verdict: [ACTIONABLE | RESPONSE-NEEDED | FYI | NOISE] — [one-sentence reason, max 15 words]
+
+- bullet 1
+- bullet 2
+- bullet 3
+```
+
+For **NOISE**, skip the bullet list and emit only one bullet describing what kind of noise it is.
+
+### Verdict definitions
+
+| Verdict | When |
+|---|---|
+| **ACTIONABLE** | Email has a concrete task or deadline for the reader |
+| **RESPONSE-NEEDED** | Sender is waiting on the reader's answer |
+| **FYI** | Informational only, no action expected |
+| **NOISE** | Promotional, automated, generic recruiting, purely social, **or a likely scam** |
+
+### NOISE scam patterns to name explicitly
+
+When the email looks like a common scam or low-quality outreach, name the pattern in the verdict's reason line:
+
+- **"likely fake recruiter"** — generic "amazing opportunity" with no company or role specifics
+- **"likely conference scam"** — invitation to a conference the reader has never engaged with, vague venue, pay-to-speak, URL mismatch
+- **"likely fake interview"** — unverified recruiter asks for a technical interview with no company profile or LinkedIn trail
+- **"crypto / MLM pitch"** — mentions crypto, token launches, multi-level marketing, "passive income"
+- **"phishing"** — urgent credential/billing request, mismatched sender domain, suspicious link shortener
+- **"generic outreach"** — no specifics, clearly a template
+
+## Handling a thread (multiple messages, same conversation)
+
+For each message, emit its own three-line block with sender + timestamp as a prefix line, then all messages plus a consolidated **Actions** section:
+
+```
+Alice — Tue 10:14
+Prompt: "Ask Bob for the vendor list by Friday."
+Verdict: RESPONSE-NEEDED — waiting on finalized list
+
+- Q3 budget capped at $50k
 - Need finalized vendor list by Friday
 
-**Bob — Tue 14:02**
-- Vendor A and B confirmed; C declined
+Bob — Tue 14:02
+Prompt: "Confirm vendors A and B, explain C decline."
+Verdict: ACTIONABLE — deliverable coming Thursday
+
+- Vendor A and B confirmed
+- Vendor C declined (timeline)
+- Contract draft Thursday
 
 **Actions**
-- Alice: approve final vendor list by Friday
-- Bob: send Vendor B contract draft by Thursday
+- Alice: approve finalized vendor list by Friday; sign Vendor B contract after Bob's draft lands
+- Bob: send Vendor B contract draft Thursday
 ```
 
-If attribution isn't clear, use the role ("Sender") or omit.
+## Handling a batch (multiple unrelated emails)
 
-### 3. Batch (multiple unrelated emails in one input)
-
-For each email, emit a short header (subject line or sender name), then 1–3 bullets.
-
-After all emails, emit a **Triage** section that classifies each into one of four buckets:
-
-- **Act now** — has a concrete action item or deadline
-- **Reply needed** — the sender is waiting on an answer
-- **FYI** — informational only, no action needed
-- **Noise** — newsletter, marketing, automated, no substantive content
-
-Format:
+For each email, emit a short header (subject or sender), then the three-line block. After all emails, emit a **Triage** section bucketing each into Act now / Reply needed / FYI / Noise:
 
 ```
 **Re: deck review**
-- Send latest deck by EOD Wed
+Prompt: "Remind team about Thursday deck review."
+Verdict: ACTIONABLE — has a deadline
 
-**LinkedIn: You appeared in X searches**
-- No substantive content; promotional.
+- Send deck by EOD Wed
+
+**LinkedIn: exclusive opportunity at "Growth Co"**
+Prompt: "Send a generic recruiter cold outreach."
+Verdict: NOISE — likely fake recruiter
+
+- Generic pitch, no company or role specifics
 
 **Triage**
 - Act now: Re: deck review
-- Noise: LinkedIn: You appeared in X searches
+- Noise: LinkedIn: exclusive opportunity at "Growth Co"
 ```
-
-## Classifying noise
-
-These are almost always noise — one-liner them:
-
-- Newsletters, marketing blasts, drip campaigns → `No substantive content; promotional.`
-- Automated system mail (build failures, monitoring alerts) → noise **unless** the content names a concrete action the user must take.
-- Auto-replies ("out of office", "will respond on [date]") → `No substantive content; out-of-office.`
-- Recruiter outreach without specifics → `No substantive content; generic recruiting.`
 
 ## Hard rules
 
-- Never summarize what the email "is about" in prose.
+- Never summarize what the email "is about" in prose. Bullets only, in the specified format.
 - Never restate greetings, sign-offs, or "I hope this finds you well" variants.
-- Never add conversational filler before or after the bullets.
-- Preserve numbers, dates, names, and amounts verbatim.
-- If a bullet would read as a vague paraphrase, cut it.
-- If the user pastes ambiguous content (not clearly email), ask briefly: "Is this a single email, a thread, or a batch?" before extracting.
+- Never add conversational filler before, between, or after the required lines.
+- Preserve numbers, dates, names, and amounts verbatim in the bullets.
+- The Prompt line is a best-guess imperative framed as the sender would write to an AI ("Ask Bob for…", "Politely decline…"). Do not copy actual email text.
+- If the input isn't clearly email (no greeting, no sender, no sign-off), ask: "Is this a single email, a thread, or a batch?" before extracting.
 
-## Example — single email
+## Example — single actionable email
 
 **Input:**
 
@@ -117,29 +124,25 @@ These are almost always noise — one-liner them:
 
 **Output:**
 
-- Send latest deck by EOD Wednesday for Thursday review
-- Hold customer logos pending legal sign-off
+```
+Prompt: "Politely ask the team for the deck by Wednesday and note the legal hold on customer logos."
+Verdict: ACTIONABLE — has a concrete deadline
 
-## Example — thread
+- Send deck by EOD Wednesday for Thursday review
+- Hold customer logos pending legal sign-off
+```
+
+## Example — NOISE, likely fake recruiter
 
 **Input:**
 
-> **From: Alice** (Tue 10:14)
-> Hi Bob — just to confirm, Q3 budget is capped at $50k. Could you get me the finalized vendor list by Friday?
->
-> **From: Bob** (Tue 14:02)
-> Will do. Vendor A and B confirmed for the platform work; Vendor C passed because the timeline doesn't fit their pipeline. I'll send over the Vendor B contract draft Thursday for your sign-off.
+> Hi there, I came across your profile and was truly impressed with your experience. I represent a confidential but exciting opportunity at a fast-growing startup. Would love to hop on a quick call to discuss!
 
 **Output:**
 
-**Alice — Tue 10:14**
-- Q3 budget capped at $50k
-- Finalized vendor list needed by Friday
+```
+Prompt: "Send a generic cold recruiter outreach that hides the company and role."
+Verdict: NOISE — likely fake recruiter
 
-**Bob — Tue 14:02**
-- Vendor A and B confirmed; Vendor C declined (timeline)
-- Vendor B contract draft arriving Thursday
-
-**Actions**
-- Alice: approve finalized vendor list by Friday; sign Vendor B contract after Bob's draft lands
-- Bob: send Vendor B contract draft Thursday
+- Generic pitch with no company name, role, or specifics.
+```

--- a/apps/outlook-addin/src/taskpane/index.html
+++ b/apps/outlook-addin/src/taskpane/index.html
@@ -53,7 +53,16 @@
       <section id="work" hidden>
         <button id="run" type="button" class="primary">De-Fluff this email</button>
         <div id="result" class="result" hidden>
-          <h2>Key points</h2>
+          <section id="prompt-block" class="prompt-block" hidden>
+            <p class="prompt-label"><span aria-hidden="true">💭</span> They probably asked an AI</p>
+            <p class="prompt-text" id="prompt-text"></p>
+          </section>
+          <div id="verdict-row" class="verdict" hidden>
+            <span class="verdict-icon" id="verdict-icon" aria-hidden="true"></span>
+            <span class="verdict-label" id="verdict-label"></span>
+            <span class="verdict-reason" id="verdict-reason"></span>
+          </div>
+          <p class="section-label" id="bullets-label" hidden>Specifics</p>
           <ul id="bullets"></ul>
         </div>
         <div id="error" class="error" hidden></div>

--- a/apps/outlook-addin/src/taskpane/main.ts
+++ b/apps/outlook-addin/src/taskpane/main.ts
@@ -6,8 +6,24 @@ import {
   toUserError,
   type ProviderConfig,
   type ProviderKind,
+  type Summary,
+  type Verdict,
   summarize,
 } from '@defluff/core';
+
+const VERDICT_LABELS: Record<Verdict, string> = {
+  actionable: 'Actionable',
+  'response-needed': 'Response needed',
+  fyi: 'FYI',
+  noise: 'Noise',
+};
+
+const VERDICT_ICONS: Record<Verdict, string> = {
+  actionable: '⚡',
+  'response-needed': '💬',
+  fyi: 'ℹ',
+  noise: '🗑',
+};
 import { getCurrentEmailText } from '../shared/email.js';
 import {
   clearProviderConfig,
@@ -108,8 +124,8 @@ async function handleRun(): Promise<void> {
   try {
     const text = await getCurrentEmailText();
     if (!text) throw new DefluffError('bad_request', 'Message body is empty.');
-    const { bullets } = await summarize({ text, provider: config });
-    renderBullets(bullets);
+    const summary = await summarize({ text, provider: config });
+    renderSummary(summary);
   } catch (err) {
     renderError(err);
   } finally {
@@ -118,15 +134,47 @@ async function handleRun(): Promise<void> {
   }
 }
 
-function renderBullets(bullets: string[]): void {
+function renderSummary(summary: Summary): void {
+  const result = byId('result');
+  result.dataset.verdict = summary.verdict ?? '';
+
+  const promptBlock = byId('prompt-block');
+  if (summary.reversedPrompt) {
+    byId<HTMLElement>('prompt-text').textContent = `“${summary.reversedPrompt}”`;
+    promptBlock.hidden = false;
+  } else {
+    promptBlock.hidden = true;
+  }
+
+  const verdictRow = byId('verdict-row');
+  if (summary.verdict) {
+    verdictRow.dataset.verdict = summary.verdict;
+    byId<HTMLElement>('verdict-icon').textContent = VERDICT_ICONS[summary.verdict];
+    byId<HTMLElement>('verdict-label').textContent = VERDICT_LABELS[summary.verdict];
+    const reasonEl = byId<HTMLElement>('verdict-reason');
+    reasonEl.textContent = summary.verdictReason ?? '';
+    verdictRow.hidden = false;
+  } else {
+    verdictRow.hidden = true;
+  }
+
   const list = byId<HTMLUListElement>('bullets');
   list.replaceChildren();
-  for (const bullet of bullets) {
-    const li = document.createElement('li');
-    li.textContent = bullet;
-    list.appendChild(li);
+  const bulletsLabel = byId('bullets-label');
+  if (summary.bullets.length > 0) {
+    for (const bullet of summary.bullets) {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    }
+    list.hidden = false;
+    bulletsLabel.hidden = false;
+  } else {
+    list.hidden = true;
+    bulletsLabel.hidden = true;
   }
-  byId('result').hidden = false;
+
+  result.hidden = false;
 }
 
 function renderError(err: unknown): void {

--- a/apps/outlook-addin/src/taskpane/styles.css
+++ b/apps/outlook-addin/src/taskpane/styles.css
@@ -112,14 +112,72 @@ button.link:hover { text-decoration: underline; background: none; color: var(--a
   border-left: 3px solid var(--accent);
   border-radius: 2px;
 }
-.result h2 {
-  margin: 0 0 8px;
+.result[data-verdict="noise"] ul { opacity: 0.65; }
+
+.prompt-block {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-left: 2px solid var(--accent);
+  border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.prompt-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.prompt-text {
+  margin: 0;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+.verdict[data-verdict="actionable"] { color: #a4262c; }
+.verdict[data-verdict="response-needed"] { color: var(--accent); }
+.verdict[data-verdict="fyi"] { color: var(--muted); }
+.verdict[data-verdict="noise"] { color: #8a8d91; }
+@media (prefers-color-scheme: dark) {
+  .verdict[data-verdict="actionable"] { color: #f28b82; }
+}
+.verdict-label {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.verdict-reason {
+  color: var(--fg);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.section-label {
+  margin: 0 0 4px;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--muted);
 }
+
 .result ul { margin: 0; padding-left: 20px; }
 .result li { margin-bottom: 4px; }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export {
 export type { ProviderConfigInput } from './config.js';
 export { DefluffError } from './errors.js';
 export type { DefluffErrorCode } from './errors.js';
-export { parseBullets } from './parse.js';
+export { parseBullets, parseSummary } from './parse.js';
 export { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
 export {
   PROVIDER_DEFAULT_MODELS,
@@ -30,4 +30,5 @@ export type {
   ProviderRunArgs,
   Summary,
   SummarizeOptions,
+  Verdict,
 } from './types.js';

--- a/packages/core/src/parse.test.ts
+++ b/packages/core/src/parse.test.ts
@@ -1,40 +1,88 @@
 import { describe, expect, it } from 'vitest';
-import { parseBullets } from './parse.js';
+import { parseBullets, parseSummary } from './parse.js';
 
-describe('parseBullets', () => {
-  it('parses dash bullets', () => {
+describe('parseBullets (legacy)', () => {
+  it('parses bullets when the response has no verdict or prompt', () => {
     const raw = '- First point\n- Second point\n- Third';
     expect(parseBullets(raw)).toEqual(['First point', 'Second point', 'Third']);
   });
 
-  it('parses asterisk and unicode bullets', () => {
-    expect(parseBullets('* alpha\n• beta\n· gamma')).toEqual(['alpha', 'beta', 'gamma']);
+  it('returns empty array when no bullets present', () => {
+    expect(parseBullets('This response has no bullets at all.')).toEqual([]);
   });
+});
 
-  it('parses numbered lists (dot and paren)', () => {
-    expect(parseBullets('1. first\n2) second\n10. tenth')).toEqual(['first', 'second', 'tenth']);
-  });
-
-  it('drops preamble and trailing lines without markers', () => {
+describe('parseSummary', () => {
+  it('extracts reversedPrompt, verdict, reason, and bullets', () => {
     const raw = [
-      'Here are the key points:',
+      'Prompt: "Politely ask the team for the deck by Wednesday."',
+      'Verdict: ACTIONABLE — deadline-driven request',
       '',
-      '- Need a timeline by Friday',
-      '- Budget cap is $5k',
-      '',
-      'Let me know if you need anything else.',
+      '- Send deck by EOD Wednesday',
+      '- Hold customer logos pending legal sign-off',
     ].join('\n');
-    expect(parseBullets(raw)).toEqual(['Need a timeline by Friday', 'Budget cap is $5k']);
-  });
 
-  it('strips inline bold markup', () => {
-    expect(parseBullets('- **Urgent**: send the deck\n- __blocker__ resolved')).toEqual([
-      'Urgent: send the deck',
-      'blocker resolved',
+    const summary = parseSummary(raw);
+    expect(summary.reversedPrompt).toBe('Politely ask the team for the deck by Wednesday.');
+    expect(summary.verdict).toBe('actionable');
+    expect(summary.verdictReason).toBe('deadline-driven request');
+    expect(summary.bullets).toEqual([
+      'Send deck by EOD Wednesday',
+      'Hold customer logos pending legal sign-off',
     ]);
   });
 
-  it('returns empty array when no bullets present', () => {
-    expect(parseBullets('This response has no bullets at all.')).toEqual([]);
+  it('handles all four verdict tokens', () => {
+    const samples: Array<[string, string]> = [
+      ['Verdict: RESPONSE-NEEDED — waiting on approval', 'response-needed'],
+      ['Verdict: FYI — informational only', 'fyi'],
+      ['Verdict: NOISE — generic recruiter outreach', 'noise'],
+      ['Verdict: ACTIONABLE — has a deadline', 'actionable'],
+    ];
+    for (const [line, expected] of samples) {
+      expect(parseSummary(line).verdict).toBe(expected);
+    }
+  });
+
+  it('accepts NOISE with only the prompt + verdict and zero bullets', () => {
+    const raw = [
+      'Prompt: "Write a generic recruiting outreach."',
+      'Verdict: NOISE — boilerplate recruiter pitch',
+    ].join('\n');
+    const summary = parseSummary(raw);
+    expect(summary.verdict).toBe('noise');
+    expect(summary.bullets).toEqual([]);
+  });
+
+  it('strips fancy quotes around the reversed prompt', () => {
+    const raw = 'Prompt: "Ask for the numbers"\nVerdict: FYI — informational';
+    expect(parseSummary(raw).reversedPrompt).toBe('Ask for the numbers');
+  });
+
+  it('is lenient to bold markup on labels', () => {
+    const raw = [
+      '**Prompt:** "Ask for review"',
+      '**Verdict:** ACTIONABLE — needs input',
+      '- Review needed by Friday',
+    ].join('\n');
+    const summary = parseSummary(raw);
+    expect(summary.reversedPrompt).toBe('Ask for review');
+    expect(summary.verdict).toBe('actionable');
+    expect(summary.bullets).toEqual(['Review needed by Friday']);
+  });
+
+  it('tolerates a verdict without an explicit reason', () => {
+    const raw = 'Verdict: FYI\n- Stats are posted';
+    const summary = parseSummary(raw);
+    expect(summary.verdict).toBe('fyi');
+    expect(summary.verdictReason).toBeUndefined();
+  });
+
+  it('still parses when prompt / verdict lines are missing', () => {
+    const raw = '- Send deck by Friday\n- Hold logos';
+    const summary = parseSummary(raw);
+    expect(summary.reversedPrompt).toBeUndefined();
+    expect(summary.verdict).toBeUndefined();
+    expect(summary.bullets).toHaveLength(2);
   });
 });

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -1,29 +1,111 @@
+import type { Summary, Verdict } from './types.js';
+
 const BULLET_PATTERNS: readonly RegExp[] = [
   /^[-*•·]\s+(.+)$/,
   /^\d+[.)]\s+(.+)$/,
 ];
 
+const VERDICT_MAP: Record<string, Verdict> = {
+  ACTIONABLE: 'actionable',
+  'RESPONSE-NEEDED': 'response-needed',
+  RESPONSENEEDED: 'response-needed',
+  'RESPONSE NEEDED': 'response-needed',
+  FYI: 'fyi',
+  NOISE: 'noise',
+};
+
 /**
- * Extract bullet strings from a model response. Lenient: accepts `-`, `*`, `•`,
- * `·`, `1.`, `1)` markers. Lines without a recognized marker are ignored, so a
- * preamble like "Here are the key points:" gets silently dropped.
+ * Parse a model response into a structured Summary. The LLM is instructed
+ * to produce lines in a specific order, but we parse leniently so minor
+ * formatting drift doesn't break the UI.
  */
-export function parseBullets(raw: string): string[] {
-  const bullets: string[] = [];
+export function parseSummary(raw: string): Summary {
+  const result: Summary = { bullets: [] };
+
   for (const rawLine of raw.split('\n')) {
-    const line = rawLine.trim();
+    // Strip bold markers early so every downstream matcher can assume plain text.
+    const line = rawLine.replace(/\*\*/g, '').replace(/__/g, '').trim();
     if (!line) continue;
-    for (const pattern of BULLET_PATTERNS) {
-      const match = pattern.exec(line);
-      if (match && match[1]) {
-        bullets.push(stripInlineBold(match[1].trim()));
-        break;
+
+    if (result.reversedPrompt === undefined) {
+      const prompt = extractPromptLine(line);
+      if (prompt !== undefined) {
+        result.reversedPrompt = prompt;
+        continue;
       }
     }
+
+    if (result.verdict === undefined) {
+      const verdictPair = extractVerdictLine(line);
+      if (verdictPair) {
+        result.verdict = verdictPair.verdict;
+        if (verdictPair.reason) result.verdictReason = verdictPair.reason;
+        continue;
+      }
+    }
+
+    const bullet = extractBullet(line);
+    if (bullet) result.bullets.push(bullet);
   }
-  return bullets;
+
+  return result;
 }
 
-function stripInlineBold(s: string): string {
-  return s.replace(/\*\*(.+?)\*\*/g, '$1').replace(/__(.+?)__/g, '$1');
+/**
+ * Backward-compatible helper that returns just the bullet list from a raw
+ * response. Used by callers that don't yet consume the verdict / prompt.
+ */
+export function parseBullets(raw: string): string[] {
+  return parseSummary(raw).bullets;
+}
+
+function extractPromptLine(line: string): string | undefined {
+  const match = /^prompt\s*[:\-—]\s*(.+)$/i.exec(line);
+  if (!match || !match[1]) return undefined;
+  return stripQuotes(match[1].trim());
+}
+
+// Sort once at module scope; keys are static.
+const SORTED_VERDICT_KEYS = Object.keys(VERDICT_MAP).sort(
+  (a, b) => b.length - a.length,
+);
+
+function extractVerdictLine(
+  line: string,
+): { verdict: Verdict; reason?: string } | undefined {
+  const match = /^verdict\s*[:\-—]\s*(.+)$/i.exec(line);
+  if (!match || !match[1]) return undefined;
+  const rest = match[1].trim();
+  const upper = rest.toUpperCase();
+
+  // Longest-first key match avoids stopping inside multi-word verdicts like
+  // RESPONSE-NEEDED. Boundary check ensures we don't falsely match a prefix
+  // (e.g., NOISE matching NOISEMAKER).
+  for (const key of SORTED_VERDICT_KEYS) {
+    if (!upper.startsWith(key)) continue;
+    const boundary = upper.charAt(key.length);
+    if (boundary !== '' && !/[\s—–\-:,]/.test(boundary)) continue;
+    const verdict = VERDICT_MAP[key];
+    if (!verdict) continue;
+    const reason = rest.slice(key.length).replace(/^[\s—–\-:,]+/, '').trim();
+    return reason ? { verdict, reason } : { verdict };
+  }
+  return undefined;
+}
+
+function extractBullet(line: string): string | undefined {
+  for (const pattern of BULLET_PATTERNS) {
+    const match = pattern.exec(line);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+  return undefined;
+}
+
+function stripQuotes(s: string): string {
+  return s
+    .replace(/^["'“‘«]\s*/, '')
+    .replace(/\s*["'”’»]$/, '')
+    .trim();
 }

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,15 +1,56 @@
 /**
- * The exact extraction prompt is load-bearing. Do not soften, expand, or rephrase
- * without updating requirements.md §4.4 — this wording is what keeps the output
- * terse and fluff-free. Loosening it reintroduces the padding the product exists
- * to remove.
+ * The extraction prompt is load-bearing. It instructs the model to do three
+ * things in order:
+ *
+ *   1. Reverse-engineer the prompt the sender probably gave an AI to generate
+ *      this email. This is the soul of the product — "reverse-ai."
+ *   2. Classify the email into one verdict that frames the reader's attention.
+ *   3. Extract the specifics as a concise bullet list.
+ *
+ * NOISE covers promotional, automated, generic recruiting, AND the common
+ * scam patterns the reader is most likely to see on LinkedIn: fake
+ * conferences, fake interviews, crypto/MLM pitches, phishing. The verdict's
+ * reason line names the specific pattern when one is identified so the
+ * reader can act accordingly.
+ *
+ * Do not soften, expand, or rephrase the instructions without also updating
+ * `requirements.md` §4.4 — loosening this wording is exactly how the output
+ * regains the fluff we're stripping.
  */
-export const SYSTEM_PROMPT =
-  'You are an extraction tool. Analyze the following email. Strip away all ' +
-  'pleasantries, corporate jargon, and likely AI-generated padding. Output only ' +
-  "the core facts, the sender's underlying intent, and any specific action items " +
-  'or questions requested. Format strictly as a concise, 3-5 bullet point list. ' +
-  'Do not add conversational filler.';
+export const SYSTEM_PROMPT = [
+  'You are an AI-reversal tool. Many corporate and outreach emails are padded',
+  'by LLMs; your job is to (1) guess what the sender probably asked an AI to',
+  'generate, and (2) extract the real intent.',
+  '',
+  'Output EXACTLY in this order, with these line prefixes:',
+  '',
+  'Prompt: "[short imperative the sender probably gave an AI, in quotes]"',
+  'Verdict: [ACTIONABLE | RESPONSE-NEEDED | FYI | NOISE] — [one-sentence reason, max 15 words]',
+  '',
+  'Then 3-5 bullets of specifics:',
+  '- bullet',
+  '- bullet',
+  '',
+  'Verdict definitions:',
+  '- ACTIONABLE — the email has a concrete task or deadline for the reader.',
+  '- RESPONSE-NEEDED — the sender is waiting on the reader\'s answer.',
+  '- FYI — informational only, no action expected.',
+  '- NOISE — promotional, automated, generic recruiting, purely social, OR a',
+  '  likely scam (fake conference invitations, fake interviews, crypto/MLM',
+  '  pitches, phishing asks, "amazing opportunity" outreach with no specifics).',
+  '  When NOISE is a specific scam pattern, name it in the reason line',
+  '  (e.g., "likely fake recruiter", "likely conference scam").',
+  '',
+  'Rules:',
+  '- The Prompt line is a best-guess imperative, phrased as the sender would',
+  '  write to an AI (e.g., "Politely ask the team for the deck by Wednesday").',
+  '  Do not copy actual email text.',
+  '- For NOISE, emit only one bullet describing what kind of noise or scam',
+  '  pattern it is. Do not pretend there is a substantive ask if there is not.',
+  '- Strip pleasantries, corporate jargon, and AI-generated padding.',
+  '- Preserve numbers, dates, names, amounts verbatim.',
+  '- No conversational filler before, between, or after the required lines.',
+].join('\n');
 
 export function buildUserPrompt(emailText: string): string {
   return `<email>\n${emailText.trim()}\n</email>`;

--- a/packages/core/src/summarize.test.ts
+++ b/packages/core/src/summarize.test.ts
@@ -10,21 +10,24 @@ function mockFetchOnce(status: number, payload: unknown): void {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
 }
 
+const MODEL_RESPONSE = [
+  'Prompt: "Ask the team for the deck by EOD Wednesday."',
+  'Verdict: ACTIONABLE — has a concrete deadline',
+  '',
+  '- Send deck by EOD Wednesday',
+  '- Hold customer logos pending legal',
+  '- Review with Jane on Thursday',
+].join('\n');
+
 describe('summarize', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it('returns parsed bullets from an OpenAI-shaped response', async () => {
+  it('returns parsed bullets plus verdict metadata from an OpenAI-shaped response', async () => {
     mockFetchOnce(200, {
-      choices: [
-        {
-          message: {
-            content: '- Need signoff by EOD Thursday\n- Blocker: missing legal review\n- Meeting tomorrow 10am',
-          },
-        },
-      ],
+      choices: [{ message: { content: MODEL_RESPONSE } }],
     });
 
     const result = await summarize({
@@ -33,7 +36,8 @@ describe('summarize', () => {
     });
 
     expect(result.bullets).toHaveLength(3);
-    expect(result.bullets[0]).toBe('Need signoff by EOD Thursday');
+    expect(result.verdict).toBe('actionable');
+    expect(result.reversedPrompt).toMatch(/deck by EOD Wednesday/);
   });
 
   it('rejects empty email text', async () => {
@@ -42,7 +46,7 @@ describe('summarize', () => {
     ).rejects.toBeInstanceOf(DefluffError);
   });
 
-  it('throws no_bullets when the model returns prose only', async () => {
+  it('throws no_bullets only when verdict is not NOISE', async () => {
     mockFetchOnce(200, {
       choices: [{ message: { content: 'The sender wants help with the deck.' } }],
     });
@@ -53,6 +57,23 @@ describe('summarize', () => {
         provider: { kind: 'openai', apiKey: 'sk-test' },
       }),
     ).rejects.toMatchObject({ code: 'no_bullets' });
+  });
+
+  it('allows a NOISE response with zero bullets', async () => {
+    const noiseResponse = [
+      'Prompt: "Write a generic recruiter blast."',
+      'Verdict: NOISE — boilerplate recruiting pitch',
+    ].join('\n');
+    mockFetchOnce(200, {
+      choices: [{ message: { content: noiseResponse } }],
+    });
+
+    const result = await summarize({
+      text: 'Hey! Saw your profile...',
+      provider: { kind: 'openai', apiKey: 'sk-test' },
+    });
+    expect(result.verdict).toBe('noise');
+    expect(result.bullets).toEqual([]);
   });
 
   it('maps a 401 response to an auth error', async () => {

--- a/packages/core/src/summarize.ts
+++ b/packages/core/src/summarize.ts
@@ -1,5 +1,5 @@
 import { DefluffError } from './errors.js';
-import { parseBullets } from './parse.js';
+import { parseSummary } from './parse.js';
 import { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
 import {
   anthropicAdapter,
@@ -22,13 +22,13 @@ export async function summarize(opts: SummarizeOptions): Promise<Summary> {
   };
 
   const raw = await dispatchProvider(provider, args);
-  const bullets = parseBullets(raw);
-  if (bullets.length === 0) {
+  const summary = parseSummary(raw);
+  if (summary.bullets.length === 0 && summary.verdict !== 'noise') {
     throw new DefluffError('no_bullets', 'Provider returned no parseable bullets.', {
       detail: { raw },
     });
   }
-  return { bullets };
+  return summary;
 }
 
 function dispatchProvider(provider: ProviderConfig, args: ProviderRunArgs): Promise<string> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,7 +31,16 @@ export type ProviderConfig =
   | GeminiConfig
   | OpenAICompatibleConfig;
 
+export type Verdict = 'actionable' | 'response-needed' | 'fyi' | 'noise';
+
 export interface Summary {
+  /** Best-guess imperative the sender probably gave an AI. The reversal. */
+  reversedPrompt?: string;
+  /** Verdict classifying how much attention the email deserves. */
+  verdict?: Verdict;
+  /** One-sentence justification for the verdict. */
+  verdictReason?: string;
+  /** Extracted specifics — facts, actions, questions. */
   bullets: string[];
 }
 

--- a/requirements.md
+++ b/requirements.md
@@ -30,8 +30,13 @@ To reach the widest audience with the best user experience, the product requires
 1.  **Trigger:** User opens an email and clicks the "De-Fluff" button.
 2.  **Extraction:** The client grabs the `innerText` of the email body, stripping away HTML formatting, signatures, and tracking pixels.
 3.  **Transmission:** The raw text is sent securely to your backend via an HTTPS POST request.
-4.  **LLM Processing:** The backend feeds the text into the LLM with a highly restrictive system prompt:
-    > *"You are an extraction tool. Analyze the following email. Strip away all pleasantries, corporate jargon, and likely AI-generated padding. Output only the core facts, the sender's underlying intent, and any specific action items or questions requested. Format strictly as a concise, 3-5 bullet point list. Do not add conversational filler."*
+4.  **LLM Processing:** The backend (or, in the current architecture, the client) feeds the text into the LLM with a highly restrictive system prompt that does the *reversal* the product is named for. The authoritative prompt lives in `packages/core/src/prompt.ts`. In summary, it instructs the model to produce three things in order:
+
+    1. **Prompt line** — `Prompt: "..."` — the model's best guess at the imperative the sender probably gave an AI to generate the email.
+    2. **Verdict line** — `Verdict: [ACTIONABLE | RESPONSE-NEEDED | FYI | NOISE] — reason` — classifies the email's urgency. NOISE covers promotional, automated, generic recruiting, AND likely scam patterns (fake conferences, fake interviews, crypto/MLM pitches, phishing, generic "amazing opportunity" outreach).
+    3. **Specifics** — a concise 3–5 bullet list of the actual facts, questions, and action items. For NOISE emails, a single bullet identifying the pattern.
+
+    The prompt is load-bearing: loosening its restrictive framing is how the output regains the fluff we're stripping. Changes to the wording require updating both this section and `packages/core/src/prompt.ts` in the same commit.
 5.  **Return & Display:** The backend sends the bulleted JSON/Markdown back to the client.
 6.  **UI Update:** The client visually collapses the original long email and overlays the clean, bulleted summary. A "Show Original" toggle is provided to restore the full text.
 


### PR DESCRIPTION
The project is literally called **reverse-ai** and it was shipping bullets. This PR delivers what the name promises.

## What the output looks like now

Every extraction produces three blocks:

1. **"💭 They probably asked an AI"** — the reversed prompt in italics.
2. **Verdict** — ACTIONABLE / RESPONSE-NEEDED / FYI / NOISE, color-coded, with a one-sentence reason.
3. **Specifics** — 3–5 bullets.

For NOISE emails, bullets collapse to one line describing the pattern, and the panel visually de-emphasizes the list so the reader's eye lands on the verdict first.

## NOISE covers LinkedIn-style scams explicitly

Prompt now names these patterns in the verdict reason:

- likely fake recruiter (generic "amazing opportunity", no specifics)
- likely conference scam (pay-to-speak, vague venue, URL mismatch)
- likely fake interview
- crypto / MLM pitch
- phishing
- generic outreach

## Changes

**Core** (`@defluff/core`):
- `prompt.ts` rewritten for the three-part output.
- `Summary` type extended with `reversedPrompt`, `verdict`, `verdictReason`.
- `parseSummary()` extracts all three; lenient re: bold, fancy quotes, verdict-token variants.
- 9 parser tests + 5 summarize tests. Suite at 31/31.

**Extension**: Shadow-DOM panel rewritten to render the prompt block, color-coded verdict row, and Specifics list. Dark-mode variants for each.

**Outlook add-in**: task pane result region expanded with prompt-block + verdict row + Specifics label, matching Fluent-ish styling.

**Skill** (`apps/openclaw-skill`): bumped to **0.0.4**. Thread and batch examples updated to emit the Prompt/Verdict/bullets triplet per message. NOISE scam-pattern catalogue and examples added.

**Spec**: `requirements.md` §4.4 rewritten; `CLAUDE.md` realigned.

## Skill publish

Will run `pnpm skill:publish` after merge (version `0.0.4` is baked into SKILL.md frontmatter).