### PR TITLE
fix(extension): Outlook selector — leaf-only role=document to stop button cascade

### DIFF
--- a/apps/extension/src/content/hosts/outlook.ts
+++ b/apps/extension/src/content/hosts/outlook.ts
@@ -1,15 +1,16 @@
 import { startHost } from '../ui/wireHost.js';
 
 // Outlook Web localizes aria-labels, so "Message body" only matches English
-// UIs. `role="document"` is typical for the rendered email body and is
-// language-neutral; `[data-convid]` appears on the conversation reader in
-// new Outlook. We try each in order; the first hit wins for each body.
+// UIs. `role="document"` is the language-neutral anchor for a rendered
+// message — but new Outlook nests several role=document widgets inside each
+// reader pane, which caused a cascade of De-Fluff buttons. We only match the
+// **innermost** role=document (the leaf), using `:not(:has(...))`.
 //
 // Last audited: 2026-04-20 against outlook.office.com (Lithuanian locale).
 const BODY_SELECTOR = [
-  '[role="main"] [role="document"]',
+  '[role="main"] [role="document"]:not(:has([role="document"]))',
   '[role="main"] [aria-label*="Message body"]',
-  '[role="main"] [data-convid]',
+  '[role="main"] [data-convid]:not(:has([data-convid]))',
 ].join(', ');
 
 export function startOutlook(): void {


### PR DESCRIPTION
Reported live: after v0.0.5 the user saw an "endless" number of De-Fluff buttons in new Outlook Web. `[role="document"]` matches several nested widgets per reader pane, and `startHost` wired a button to each.

Fix: restrict to the innermost `role=document` (leaf only) using `:not(:has([role="document"]))`. Same for `[data-convid]`. CSS `:has()` is supported in all evergreen browsers since 2023.

Merge + rebuild + hard-refresh Outlook → should see one button per message, not a cascade.