### PR TITLE
fix(extension): anchor Outlook on UniqueMessageBody_N id pattern

### DIFF
--- a/apps/extension/src/content/hosts/outlook.ts
+++ b/apps/extension/src/content/hosts/outlook.ts
@@ -1,16 +1,18 @@
 import { startHost } from '../ui/wireHost.js';
 
-// Outlook Web localizes aria-labels, so "Message body" only matches English
-// UIs. `role="document"` is the language-neutral anchor for a rendered
-// message — but new Outlook nests several role=document widgets inside each
-// reader pane, which caused a cascade of De-Fluff buttons. We only match the
-// **innermost** role=document (the leaf), using `:not(:has(...))`.
+// Outlook Web's most stable anchor is the `UniqueMessageBody_N` id pattern
+// on each expanded message's body div. Language-neutral and the id prefix
+// has survived multiple Outlook UI rewrites. The English aria-label and the
+// leaf role=document selectors are kept as fallbacks for cases where the
+// id pattern ever changes.
 //
 // Last audited: 2026-04-20 against outlook.office.com (Lithuanian locale).
+// Live-verified DOM: <div id="UniqueMessageBody_5" role="document"
+// aria-label="Pranešimo tekstas" class="OuGoX BIZfh">
 const BODY_SELECTOR = [
-  '[role="main"] [role="document"]:not(:has([role="document"]))',
+  '[role="main"] [id^="UniqueMessageBody"]',
   '[role="main"] [aria-label*="Message body"]',
-  '[role="main"] [data-convid]:not(:has([data-convid]))',
+  '[role="main"] [role="document"]:not(:has([role="document"]))',
 ].join(', ');
 
 export function startOutlook(): void {


### PR DESCRIPTION
Live DOM from `outlook.office.com` (Lithuanian locale) confirms the message body is always:

```html
<div id="UniqueMessageBody_N" role="document" aria-label="...">
```

The `UniqueMessageBody_` id prefix is stable, language-neutral, and unique per expanded message. Better anchor than `role=document` (which some Outlook UI variants nest) or `aria-label` (which is localized).

Selector chain: `UniqueMessageBody_` first, English `aria-label` second, leaf `role=document` last.