### PR TITLE
fix: per-entry wired-marker filter + cleaner selectors + LinkedIn indent

### DIFF
--- a/apps/extension/src/content/hosts/linkedin.ts
+++ b/apps/extension/src/content/hosts/linkedin.ts
@@ -1,17 +1,22 @@
 import { startHost } from '../ui/wireHost.js';
 
-// LinkedIn messaging DOM (2025-ish): individual messages live in
-// .msg-s-event-listitem__body under the conversation pane. Like Gmail and
-// Outlook this is a best-effort starting point — validate against live
-// LinkedIn and update the selector when it changes.
+// LinkedIn messaging DOM: each message lives in .msg-s-event-listitem__body.
+// The sender avatar is a sibling of the message content column, so the
+// content column starts indented ~56px from the left. Appending the button
+// to body.parentElement lands it under the body but at the left edge — we
+// use decorateButton to indent the Shadow DOM host past the avatar column
+// so the button sits beneath the message text itself.
 //
-// LinkedIn places the sender avatar as a sibling of the message content.
-// Prepending to the body's parent crowds the avatar; we append instead so
-// the button lands below the message, with breathing room.
+// Last audited: 2026-04-20.
 export function startLinkedIn(): void {
   startHost({
     bodySelector: '.msg-s-event-listitem__body',
     findAnchor: (body) => body.parentElement ?? body,
     insertAs: 'last',
+    decorateButton: (host) => {
+      host.style.marginLeft = '64px';
+      host.style.marginTop = '6px';
+      host.style.marginBottom = '6px';
+    },
   });
 }

--- a/apps/extension/src/content/hosts/outlook.ts
+++ b/apps/extension/src/content/hosts/outlook.ts
@@ -1,23 +1,16 @@
 import { startHost } from '../ui/wireHost.js';
 
-// Outlook Web's most stable anchor is the `UniqueMessageBody_N` id pattern
-// on each expanded message's body div. Language-neutral and the id prefix
-// has survived multiple Outlook UI rewrites. The English aria-label and the
-// leaf role=document selectors are kept as fallbacks for cases where the
-// id pattern ever changes.
+// Outlook Web's message body always has an `id` starting with
+// `UniqueMessageBody_`. Verified live on outlook.office.com (Lithuanian
+// locale) with both single and threaded conversation views:
+//   <div id="UniqueMessageBody_1" role="document" ...>
+//   <div id="UniqueMessageBody_5" role="document" ...>
 //
-// Last audited: 2026-04-20 against outlook.office.com (Lithuanian locale).
-// Live-verified DOM: <div id="UniqueMessageBody_5" role="document"
-// aria-label="Pranešimo tekstas" class="OuGoX BIZfh">
-const BODY_SELECTOR = [
-  '[role="main"] [id^="UniqueMessageBody"]',
-  '[role="main"] [aria-label*="Message body"]',
-  '[role="main"] [role="document"]:not(:has([role="document"]))',
-].join(', ');
-
+// This id prefix is language-neutral and has outlasted multiple Outlook UI
+// revamps. Any future regression: re-audit and update in place.
 export function startOutlook(): void {
   startHost({
-    bodySelector: BODY_SELECTOR,
+    bodySelector: '[role="main"] [id^="UniqueMessageBody"]',
     findAnchor: (body) => body.parentElement ?? body,
   });
 }

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -11,8 +11,9 @@ const TRIGGERS = new WeakMap<HTMLElement, () => void>();
 
 export interface HostStrategy {
   /**
-   * Selector for a "wire-eligible" message body. The caller does not need to
-   * include the marker — wireHost appends `:not([data-defluff-wired])`.
+   * Selector for a "wire-eligible" message body. May contain comma-separated
+   * alternatives — the caller does not need to include the marker filter;
+   * wireHost applies `:not([data-defluff-wired])` to every entry.
    */
   bodySelector: string;
   /**
@@ -29,6 +30,12 @@ export interface HostStrategy {
    * below the message, away from the profile picture.
    */
   insertAs?: 'first' | 'last';
+  /**
+   * Per-host style tweaks applied to the Shadow DOM host element after it's
+   * created. Hosts like LinkedIn use this to indent the button past the
+   * avatar column.
+   */
+  decorateButton?(host: HTMLElement): void;
 }
 
 /**
@@ -43,15 +50,23 @@ export interface HostStrategy {
 export function startHost(strategy: HostStrategy): () => void {
   let pending = false;
 
+  // Apply the :not([marker]) filter to EVERY entry in the comma-separated
+  // selector list. Appending it to the full string only scopes it to the
+  // final entry in CSS grammar, which caused wired elements to match again
+  // on every MutationObserver tick.
+  const scopedSelector = strategy.bodySelector
+    .split(/\s*,\s*/)
+    .filter(Boolean)
+    .map((s) => `${s}:not([${MARKER}])`)
+    .join(', ');
+
   const scan = (): void => {
-    const bodies = document.querySelectorAll<HTMLElement>(
-      `${strategy.bodySelector}:not([${MARKER}])`,
-    );
+    const bodies = document.querySelectorAll<HTMLElement>(scopedSelector);
     if (bodies.length === 0) return;
     for (const body of bodies) {
       body.setAttribute(MARKER, 'true');
       const anchor = strategy.findAnchor(body);
-      wireTarget(body, anchor, strategy.insertAs ?? 'first');
+      wireTarget(body, anchor, strategy.insertAs ?? 'first', strategy.decorateButton);
     }
   };
 
@@ -118,6 +133,7 @@ function wireTarget(
   body: HTMLElement,
   anchor: HTMLElement,
   insertAs: 'first' | 'last',
+  decorateButton?: (host: HTMLElement) => void,
 ): void {
   let activePanel: { remove: () => void; focus: () => void } | null = null;
   let originalDisplay = '';
@@ -192,6 +208,7 @@ function wireTarget(
   button = createButton(() => {
     void trigger();
   });
+  decorateButton?.(button.element);
   TRIGGERS.set(button.element, () => void trigger());
   if (insertAs === 'last') {
     anchor.appendChild(button.element);


### PR DESCRIPTION
Three fixes from live-testing round.

## Real bug: comma-separated selectors weren't marker-filtered per entry

`startHost` used to append `:not([data-defluff-wired])` to the whole selector string:

```ts
// Before (bug):
const bodies = document.querySelectorAll(`${selector}:not([data-defluff-wired])`);
```

In CSS grammar, `A, B, C:not(...)` only scopes `:not` to `C`. So with the current Outlook selector `[role="main"] [id^="UniqueMessageBody"], ...`, the FIRST entry matched already-wired elements on every MutationObserver tick. Depending on timing this could either re-wire (cascade) or race with the marker assignment, producing inconsistent behavior.

Fix: split on commas, apply the filter per entry, rejoin.

## Outlook selector simplified to just `UniqueMessageBody_`

Both live DOM dumps confirmed the same pattern:

```html
<div id="UniqueMessageBody_1" role="document" aria-label="...">
<div id="UniqueMessageBody_5" role="document" aria-label="...">
```

The id prefix is language-neutral and has outlasted Outlook UI revamps. Fallbacks added bug surface without pulling weight, now dropped.

## LinkedIn indent

User reported the button lands at the left edge of the message group, under the avatar column instead of under the message text itself. Added a `decorateButton(host)` hook on `HostStrategy`; LinkedIn uses it to indent the Shadow DOM host by 64px past the avatar column, plus a bit of vertical breathing room.