### PR TITLE
fix(extension): restore [role=document] as Outlook anchor (OR'd with id)

### DIFF
--- a/apps/extension/src/content/hosts/outlook.ts
+++ b/apps/extension/src/content/hosts/outlook.ts
@@ -1,16 +1,18 @@
 import { startHost } from '../ui/wireHost.js';
 
-// Outlook Web's message body always has an `id` starting with
-// `UniqueMessageBody_`. Verified live on outlook.office.com (Lithuanian
-// locale) with both single and threaded conversation views:
-//   <div id="UniqueMessageBody_1" role="document" ...>
-//   <div id="UniqueMessageBody_5" role="document" ...>
+// Outlook Web's message body has both:
+//   - role="document"
+//   - id starting with "UniqueMessageBody_"
+// on the same element. The user confirmed role=document was matching live
+// (cascading was a separate wireHost bug fixed in PR #26). Using both
+// anchors as OR alternatives gives belt-and-suspenders resilience to
+// future Outlook revamps — if they drop the id prefix, role=document
+// still works; if they drop the role, the id still works.
 //
-// This id prefix is language-neutral and has outlasted multiple Outlook UI
-// revamps. Any future regression: re-audit and update in place.
+// Last audited: 2026-04-20 against outlook.office.com (Lithuanian locale).
 export function startOutlook(): void {
   startHost({
-    bodySelector: '[role="main"] [id^="UniqueMessageBody"]',
+    bodySelector: '[role="main"] [id^="UniqueMessageBody"], [role="main"] [role="document"]',
     findAnchor: (body) => body.parentElement ?? body,
   });
 }


### PR DESCRIPTION
User confirmed: `[role="main"] [role="document"]` *was* matching live Outlook in PR #23 — the problem back then was the cascade, which turned out to be an unrelated bug in the marker filter (fixed in PR #26). Swapping to `[id^="UniqueMessageBody"]` in PR #25 unintentionally regressed the matching side.

Likely cause: Outlook probably sets `role="document"` on element creation and assigns the `UniqueMessageBody_N` id later. Our childList-only MutationObserver doesn't re-scan on attribute changes, so the id selector misses the element entirely.

**Using both anchors OR'd** gives resilience to both timing and future UI revamps. `querySelectorAll` deduplicates; the per-entry marker filter from PR #26 prevents re-wiring.