### PR TITLE
fix(plugin): use live github.io homepage, drop aspirational defluff.app

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "source": "./apps/claude-skill",
       "description": "Reverse the AI in corporate email: guess the prompt the sender gave an LLM, classify urgency, extract 3–5 bullets of real intent. Detects invoice fraud / BEC, phishing, fake recruiters, and other scam red flags.",
       "version": "0.1.0",
-      "homepage": "https://defluff.app",
+      "homepage": "https://finaegis.github.io/defluff/",
       "repository": "https://github.com/FinAegis/defluff",
       "license": "MIT",
       "keywords": ["email", "summarization", "productivity", "triage", "scam-detection"],

--- a/apps/claude-skill/.claude-plugin/plugin.json
+++ b/apps/claude-skill/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "FinAegis"
   },
-  "homepage": "https://defluff.app",
+  "homepage": "https://finaegis.github.io/defluff/",
   "repository": "https://github.com/FinAegis/defluff",
   "license": "MIT",
   "keywords": ["email", "summarization", "productivity", "triage", "scam-detection"]

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -41,7 +41,7 @@ Everything shares one ~500-line `@defluff/core` package that owns the extraction
 Feedback welcome, especially from anyone whose enterprise has banned every mainstream AI summarizer on data-residency grounds. That's who this was built for.
 
 Repo: https://github.com/FinAegis/defluff
-Landing: https://defluff.app (coming)
+Landing: https://finaegis.github.io/defluff/
 
 ---
 


### PR DESCRIPTION
## Summary

- \`defluff.app\` is not registered. I added it to three places in #28 (plugin.json, marketplace.json, launch.md) after copying the \`(coming)\` placeholder in launch.md without verifying — my mistake.
- Swaps in \`https://finaegis.github.io/defluff/\`, which actually serves the landing page today.
- \`claude plugin validate .\` still passes.

## Test plan

- [ ] \`claude plugin install defluff@finaegis\` shows the correct homepage link in \`/plugin\`
- [ ] The Anthropic plugin submission form (in-progress) uses the same URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)