### PR TITLE
feat(linkedin): thread-mode — catch progressive-reveal scams across messages

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,10 +1,12 @@
-import { DefluffError, summarize } from '@defluff/core';
+import { DefluffError, summarize, summarizeThread, type ThreadMessage } from '@defluff/core';
 import {
   MSG_OPEN_OPTIONS,
   MSG_SUMMARIZE,
+  MSG_SUMMARIZE_THREAD,
   MSG_TRIGGER_ACTIVE,
   type AppRequest,
   type SummarizeResponse,
+  type SummarizeThreadResponse,
 } from './shared/messages.js';
 import { getProviderConfig } from './shared/storage.js';
 
@@ -44,6 +46,11 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
     return true; // Chrome MV3 idiom: keep the channel open for an async response.
   }
 
+  if (message.type === MSG_SUMMARIZE_THREAD) {
+    void handleSummarizeThread(message.messages).then(sendResponse);
+    return true;
+  }
+
   if (message.type === MSG_OPEN_OPTIONS) {
     void chrome.runtime.openOptionsPage();
     return undefined;
@@ -65,6 +72,29 @@ async function handleSummarize(text: string): Promise<SummarizeResponse> {
   try {
     const summary = await summarize({ text, provider });
     return { ok: true, summary };
+  } catch (err) {
+    if (err instanceof DefluffError) {
+      return { ok: false, error: err.message, code: err.code };
+    }
+    return { ok: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+async function handleSummarizeThread(
+  messages: ThreadMessage[],
+): Promise<SummarizeThreadResponse> {
+  const provider = await getProviderConfig();
+  if (!provider) {
+    return {
+      ok: false,
+      error: 'Open the Defluff options page and configure a provider first.',
+      code: 'unknown_provider',
+    };
+  }
+
+  try {
+    const thread = await summarizeThread({ messages, provider });
+    return { ok: true, thread };
   } catch (err) {
     if (err instanceof DefluffError) {
       return { ok: false, error: err.message, code: err.code };

--- a/apps/extension/src/content/hosts/linkedin.ts
+++ b/apps/extension/src/content/hosts/linkedin.ts
@@ -1,3 +1,4 @@
+import type { ThreadMessage } from '@defluff/core';
 import { startHost } from '../ui/wireHost.js';
 
 // LinkedIn messaging DOM: each message lives in .msg-s-event-listitem__body.
@@ -14,13 +15,20 @@ import { startHost } from '../ui/wireHost.js';
 // left unmarked, so if the user clicks "…see more" to expand a truncated
 // message past 400 chars, the next scan wires it.
 //
-// Last audited: 2026-04-21.
+// Thread mode: when the user clicks any message's button, we walk the
+// conversation pane and collect the full chain — sender + timestamp + body
+// per message — so the model can catch progressive-reveal scams (benign
+// recruiter intro → calendly drop → wallet ask). When only one message is
+// found, the host falls back to single-message mode transparently.
+//
+// Last audited: 2026-04-22.
 export function startLinkedIn(): void {
   startHost({
     bodySelector: '.msg-s-event-listitem__body',
     findAnchor: (body) => body.parentElement ?? body,
     insertAs: 'last',
     minBodyChars: 400,
+    extractThread,
     decorateButton: (host) => {
       host.style.marginLeft = '64px';
       host.style.marginTop = '6px';
@@ -32,4 +40,109 @@ export function startLinkedIn(): void {
       host.style.marginLeft = '64px';
     },
   });
+}
+
+/**
+ * Cap on messages sent to the model. LinkedIn conversations can run to
+ * hundreds of short messages; past the last N the scam signal is already
+ * in the recent tail, and token cost scales linearly. Eight is enough for
+ * a recruiter-scam progression (intro + clarifying exchanges + calendly
+ * drop + wallet ask) while keeping a single click cheap.
+ */
+const MAX_THREAD_MESSAGES = 8;
+
+/**
+ * Walk up from the clicked message body to the surrounding thread list and
+ * collect every message, newest-last. Defensive: if the thread list can't
+ * be found or no siblings exist, return [current body] so the caller falls
+ * back to single-message mode without surfacing an error.
+ *
+ * LinkedIn groups consecutive messages from the same sender under one
+ * avatar + name block; the name lives on the FIRST event-listitem of each
+ * run. We walk sequentially and carry the last-seen sender forward so
+ * collapsed runs still get attributed correctly.
+ *
+ * Timestamps appear in two places: per-message meta-time on the first
+ * message of each run (".msg-s-event-listitem__meta-time"), and as a
+ * separator above a run (".msg-s-message-list__time-heading"). We prefer
+ * the per-message time and fall back to the heading when absent.
+ */
+function extractThread(clickedBody: HTMLElement): ThreadMessage[] {
+  const list = findThreadList(clickedBody);
+  if (!list) return [{ body: clickedBody.innerText.trim() }];
+
+  const items = Array.from(
+    list.querySelectorAll<HTMLElement>('.msg-s-event-listitem, li.msg-s-message-list__event'),
+  );
+
+  // Some LinkedIn layouts don't tag the listitem class — fall back to
+  // walking the bodies directly and inferring context from DOM proximity.
+  if (items.length === 0) {
+    const bodies = Array.from(
+      list.querySelectorAll<HTMLElement>('.msg-s-event-listitem__body'),
+    );
+    if (bodies.length === 0) return [{ body: clickedBody.innerText.trim() }];
+    return bodies.map((body) => ({ body: body.innerText.trim() })).filter(hasBody);
+  }
+
+  const messages: ThreadMessage[] = [];
+  let lastSender: string | undefined;
+  let lastHeading: string | undefined;
+
+  for (const item of items) {
+    // Time-heading rows (run dividers) don't carry a message body but
+    // update the timestamp context used by the next run.
+    const heading = item
+      .querySelector<HTMLElement>('.msg-s-message-list__time-heading')
+      ?.innerText.trim();
+    if (heading) lastHeading = heading;
+
+    const body = item.querySelector<HTMLElement>('.msg-s-event-listitem__body');
+    if (!body) continue;
+
+    const sender =
+      item
+        .querySelector<HTMLElement>('.msg-s-message-group__name, .msg-s-event-listitem__name')
+        ?.innerText.trim() || lastSender;
+    if (sender) lastSender = sender;
+
+    const timestamp =
+      item
+        .querySelector<HTMLElement>('.msg-s-message-group__timestamp, .msg-s-event-listitem__meta-time, time')
+        ?.innerText.trim() || lastHeading;
+
+    const msg: ThreadMessage = { body: body.innerText.trim() };
+    if (sender) msg.sender = sender;
+    if (timestamp) msg.timestamp = timestamp;
+    if (hasBody(msg)) messages.push(msg);
+  }
+
+  if (messages.length === 0) return [{ body: clickedBody.innerText.trim() }];
+
+  // Truncate from the head — the most recent messages carry the scam
+  // reveal (calendly / wallet ask). The early "we'd love to chat" filler
+  // is where tokens would be wasted.
+  return messages.slice(-MAX_THREAD_MESSAGES);
+}
+
+function hasBody(msg: ThreadMessage): boolean {
+  return msg.body.length > 0;
+}
+
+function findThreadList(start: HTMLElement): HTMLElement | null {
+  let node: HTMLElement | null = start;
+  while (node) {
+    if (
+      node.classList?.contains('msg-s-message-list') ||
+      node.classList?.contains('msg-s-message-list-content')
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  // Fallback: query on document. A conversation pane can live in a portal.
+  return (
+    document.querySelector<HTMLElement>('.msg-s-message-list-content') ??
+    document.querySelector<HTMLElement>('.msg-s-message-list')
+  );
 }

--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -1,4 +1,4 @@
-import type { Authored, Summary, Verdict } from '@defluff/core';
+import type { Authored, Summary, ThreadSummary, ThreadVerdict, Verdict } from '@defluff/core';
 import {
   AUTHORED_ICONS,
   AUTHORED_LABELS,
@@ -23,9 +23,22 @@ export interface PanelError {
 
 export interface PanelOptions {
   summary?: Summary;
+  thread?: ThreadSummary;
   error?: PanelError;
   onDismiss?: () => void;
 }
+
+const THREAD_VERDICT_LABELS: Record<ThreadVerdict, string> = {
+  legit: 'Legit thread',
+  mixed: 'Mixed thread',
+  scam: 'Scam progression',
+};
+
+const THREAD_VERDICT_ICONS: Record<ThreadVerdict, string> = {
+  legit: '✓',
+  mixed: '△',
+  scam: '✕',
+};
 
 export function createPanel(opts: PanelOptions): PanelController {
   const host = document.createElement('div');
@@ -40,14 +53,23 @@ export function createPanel(opts: PanelOptions): PanelController {
   const isError = !!opts.error;
   panel.className = isError ? 'df-panel df-error' : 'df-panel';
   panel.setAttribute('role', isError ? 'alert' : 'region');
-  panel.setAttribute('aria-label', isError ? 'Defluff error' : 'Email summary');
+  panel.setAttribute(
+    'aria-label',
+    isError ? 'Defluff error' : opts.thread ? 'Thread summary' : 'Email summary',
+  );
   panel.tabIndex = -1;
-  if (!isError && opts.summary?.verdict) {
-    panel.dataset.verdict = opts.summary.verdict;
+  if (!isError) {
+    if (opts.thread?.threadVerdict) {
+      panel.dataset.threadVerdict = opts.thread.threadVerdict;
+    } else if (opts.summary?.verdict) {
+      panel.dataset.verdict = opts.summary.verdict;
+    }
   }
 
   if (isError && opts.error) {
     renderError(panel, opts.error);
+  } else if (opts.thread) {
+    renderThread(panel, opts.thread);
   } else if (opts.summary) {
     renderSummary(panel, opts.summary);
   }
@@ -233,6 +255,141 @@ function buildVerdictRow(verdict: Verdict, reason?: string): HTMLElement {
   }
 
   return row;
+}
+
+/**
+ * Render a thread-mode summary. The structure is:
+ *
+ *   [Thread-verdict strip]
+ *   ── message 1 ──────────────
+ *     [authored] [verdict] [bullets]
+ *   ── message 2 ──────────────
+ *     ...
+ *   [Actions]
+ *
+ * The thread verdict strip (LEGIT / MIXED / SCAM) is shown FIRST because
+ * it's the headline answer — especially for SCAM, the reader should see
+ * the pattern name before scrolling through per-message detail.
+ */
+function renderThread(panel: HTMLElement, thread: ThreadSummary): void {
+  const hasAnything =
+    thread.messages.length > 0 || !!thread.threadVerdict || thread.actions.length > 0;
+
+  if (!hasAnything) {
+    const heading = document.createElement('h3');
+    heading.textContent = 'No summary';
+    panel.appendChild(heading);
+    const p = document.createElement('p');
+    p.textContent =
+      'The model did not return a usable thread summary. Try again or switch models.';
+    panel.appendChild(p);
+    return;
+  }
+
+  if (thread.threadVerdict) {
+    panel.appendChild(
+      buildThreadVerdictStrip(thread.threadVerdict, thread.threadVerdictReason),
+    );
+  }
+
+  for (let i = 0; i < thread.messages.length; i++) {
+    const msg = thread.messages[i];
+    if (!msg) continue;
+    panel.appendChild(buildMessageBlock(msg, i === 0));
+  }
+
+  if (thread.actions.length > 0) {
+    panel.appendChild(buildActionsBlock(thread.actions));
+  }
+}
+
+function buildThreadVerdictStrip(verdict: ThreadVerdict, reason?: string): HTMLElement {
+  const strip = document.createElement('div');
+  strip.className = 'df-thread-verdict';
+  strip.dataset.threadVerdict = verdict;
+
+  const icon = document.createElement('span');
+  icon.className = 'df-thread-verdict-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = THREAD_VERDICT_ICONS[verdict];
+  strip.appendChild(icon);
+
+  const label = document.createElement('span');
+  label.className = 'df-thread-verdict-label';
+  label.textContent = THREAD_VERDICT_LABELS[verdict];
+  strip.appendChild(label);
+
+  if (reason) {
+    const reasonSpan = document.createElement('span');
+    reasonSpan.className = 'df-thread-verdict-reason';
+    reasonSpan.textContent = reason;
+    strip.appendChild(reasonSpan);
+  }
+  return strip;
+}
+
+function buildMessageBlock(
+  msg: ThreadSummary['messages'][number],
+  isFirst: boolean,
+): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'df-thread-message';
+  if (isFirst) section.classList.add('df-thread-message-first');
+  if (msg.summary.verdict) section.dataset.verdict = msg.summary.verdict;
+
+  const header = document.createElement('header');
+  header.className = 'df-thread-message-head';
+  const sender = document.createElement('span');
+  sender.className = 'df-thread-message-sender';
+  sender.textContent = msg.sender ?? 'Unknown sender';
+  header.appendChild(sender);
+  if (msg.timestamp) {
+    const ts = document.createElement('span');
+    ts.className = 'df-thread-message-time';
+    ts.textContent = msg.timestamp;
+    header.appendChild(ts);
+  }
+  section.appendChild(header);
+
+  const { summary } = msg;
+  const authoredBlock = buildAuthoredBlock(summary);
+  if (authoredBlock) section.appendChild(authoredBlock);
+
+  if (summary.verdict) {
+    section.appendChild(buildVerdictRow(summary.verdict, summary.verdictReason));
+  }
+
+  if (summary.bullets.length > 0) {
+    const list = document.createElement('ul');
+    for (const bullet of summary.bullets) {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    }
+    section.appendChild(list);
+  }
+
+  return section;
+}
+
+function buildActionsBlock(actions: ThreadSummary['actions']): HTMLElement {
+  const block = document.createElement('section');
+  block.className = 'df-thread-actions';
+  const label = document.createElement('p');
+  label.className = 'df-thread-actions-label';
+  label.textContent = 'Actions';
+  block.appendChild(label);
+  const list = document.createElement('ul');
+  for (const action of actions) {
+    const li = document.createElement('li');
+    const who = document.createElement('strong');
+    who.textContent = `${action.who}:`;
+    li.appendChild(who);
+    li.appendChild(document.createTextNode(` ${action.action}`));
+    list.appendChild(li);
+  }
+  block.appendChild(list);
+  return block;
 }
 
 function makeLink(label: string, onClick: () => void): HTMLButtonElement {

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -219,4 +219,99 @@ export const CONTENT_CSS = `
   white-space: nowrap;
   border: 0;
 }
+
+/* Thread mode — a thread verdict strip at the top (LEGIT / MIXED / SCAM)
+   frames the reader's attention before the per-message detail.
+   SCAM gets the error palette because that's the whole point of
+   thread mode: progressive-reveal scams. */
+.df-thread-verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: var(--df-panel-bg);
+  border: 1px solid var(--df-panel-border);
+  font-size: 13px;
+}
+.df-thread-verdict[data-thread-verdict="scam"] {
+  background: var(--df-error-bg);
+  border-color: var(--df-error-accent);
+  color: var(--df-error-accent);
+}
+.df-thread-verdict[data-thread-verdict="mixed"] {
+  color: var(--df-verdict-fyi);
+}
+.df-thread-verdict-icon { font-size: 14px; font-weight: 700; }
+.df-thread-verdict-label {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.df-thread-verdict-reason {
+  color: var(--df-fg);
+  font-weight: 400;
+  font-style: italic;
+}
+.df-thread-verdict[data-thread-verdict="scam"] .df-thread-verdict-reason { color: inherit; }
+
+/* Per-message block — a hairline-separated stack. The first block has no
+   top rule so the thread verdict strip flows into it; subsequent blocks
+   carry a top rule as the separator. */
+.df-thread-message {
+  padding: 12px 0 6px;
+  border-top: 1px solid var(--df-panel-border);
+}
+.df-thread-message.df-thread-message-first {
+  padding-top: 0;
+  border-top: none;
+}
+.df-thread-message[data-verdict="noise"] ul { opacity: 0.65; }
+
+.df-thread-message-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--df-muted);
+}
+.df-thread-message-sender {
+  font-weight: 600;
+  color: var(--df-fg);
+  font-size: 13px;
+}
+.df-thread-message-time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  letter-spacing: -0.01em;
+}
+
+/* Actions block at the bottom — a compact who/what list. Keeps the scan
+   simple: read the thread verdict, then the actions. Bullets sit as a
+   plain list without the Gmail-adjacent chrome. */
+.df-thread-actions {
+  margin: 10px 0 0;
+  padding: 10px 0 0;
+  border-top: 1px solid var(--df-panel-border);
+}
+.df-thread-actions-label {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--df-muted);
+}
+.df-thread-actions ul { margin: 0; padding-left: 18px; }
+.df-thread-actions li { margin-bottom: 4px; font-size: 13px; }
+.df-thread-actions li strong { margin-right: 4px; color: var(--df-fg); font-weight: 600; }
+
+/* Match the SCAM palette around the entire panel when the thread reads as
+   a scam — the reader needs the hint that this is not just informational. */
+.df-panel[data-thread-verdict="scam"] { border-left-color: var(--df-error-accent); }
 `;

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -1,6 +1,13 @@
-import { toUserError } from '@defluff/core';
-import type { SummarizeResponse } from '../../shared/messages.js';
-import { MSG_OPEN_OPTIONS, MSG_SUMMARIZE } from '../../shared/messages.js';
+import { toUserError, type Summary, type ThreadMessage, type ThreadSummary } from '@defluff/core';
+import type {
+  SummarizeResponse,
+  SummarizeThreadResponse,
+} from '../../shared/messages.js';
+import {
+  MSG_OPEN_OPTIONS,
+  MSG_SUMMARIZE,
+  MSG_SUMMARIZE_THREAD,
+} from '../../shared/messages.js';
 import { createButton, type ButtonController } from './button.js';
 import { createPanel, type PanelError } from './panel.js';
 
@@ -49,6 +56,16 @@ export interface HostStrategy {
    * truncated message and crosses the threshold, the next scan picks it up.
    */
   minBodyChars?: number;
+  /**
+   * Optional thread extractor. When present, the host calls it on click
+   * and sends the returned message list to the service worker as a
+   * SUMMARIZE_THREAD request. If the extractor returns ≤1 message, the
+   * host falls back to single-message SUMMARIZE so the round-trip shape
+   * is unchanged for hosts that don't have a structured thread DOM (e.g.
+   * Gmail until its adapter is updated). Defensive: the extractor MUST
+   * NOT throw — return an empty array / a single message instead.
+   */
+  extractThread?(body: HTMLElement): ThreadMessage[];
 }
 
 /**
@@ -99,6 +116,7 @@ export function startHost(strategy: HostStrategy): () => void {
         strategy.insertAs ?? 'first',
         strategy.decorateButton,
         strategy.decoratePanel,
+        strategy.extractThread,
       );
     }
   };
@@ -168,6 +186,7 @@ function wireTarget(
   insertAs: 'first' | 'last',
   decorateButton?: (host: HTMLElement) => void,
   decoratePanel?: (host: HTMLElement) => void,
+  extractThread?: (body: HTMLElement) => ThreadMessage[],
 ): void {
   let activePanel: { remove: () => void; focus: () => void } | null = null;
   let button: ButtonController;
@@ -180,15 +199,47 @@ function wireTarget(
     if (!body.isConnected) return;
     button.setBusy(true);
 
-    const emailText = body.innerText.trim();
-    let response: SummarizeResponse | undefined;
+    let thread: ThreadMessage[] | undefined;
+    if (extractThread) {
+      try {
+        thread = extractThread(body);
+      } catch {
+        thread = undefined;
+      }
+    }
+
+    let singleResponse: SummarizeResponse | undefined;
+    let threadResponse: SummarizeThreadResponse | undefined;
+
+    // Dispatch thread-mode only when we have multiple messages with
+    // actual body content. A single-element extractor result means the
+    // host is effectively single-message (e.g. Gmail, or LinkedIn where
+    // the conversation has just started). Falling back keeps latency and
+    // token cost lowest for the common case.
+    const useThread =
+      Array.isArray(thread) &&
+      thread.filter((m) => m.body.trim().length > 0).length > 1;
+
     try {
-      response = await chrome.runtime.sendMessage({ type: MSG_SUMMARIZE, text: emailText });
+      if (useThread) {
+        threadResponse = await chrome.runtime.sendMessage({
+          type: MSG_SUMMARIZE_THREAD,
+          messages: thread as ThreadMessage[],
+        });
+      } else {
+        const emailText = body.innerText.trim();
+        singleResponse = await chrome.runtime.sendMessage({
+          type: MSG_SUMMARIZE,
+          text: emailText,
+        });
+      }
     } catch (err) {
-      response = {
-        ok: false,
-        error: err instanceof Error ? err.message : 'Extension error',
-      };
+      const error = err instanceof Error ? err.message : 'Extension error';
+      if (useThread) {
+        threadResponse = { ok: false, error };
+      } else {
+        singleResponse = { ok: false, error };
+      }
     }
 
     button.setBusy(false);
@@ -196,8 +247,12 @@ function wireTarget(
     // Defensive: sendMessage can resolve with undefined if the service worker
     // terminated mid-flight before calling sendResponse. Treat as a generic
     // network-class failure rather than crashing on `response.ok`.
-    if (!response || typeof response !== 'object' || !('ok' in response)) {
-      response = { ok: false, error: 'No response from the extension. Try again.' };
+    if (useThread) {
+      if (!threadResponse || typeof threadResponse !== 'object' || !('ok' in threadResponse)) {
+        threadResponse = { ok: false, error: 'No response from the extension. Try again.' };
+      }
+    } else if (!singleResponse || typeof singleResponse !== 'object' || !('ok' in singleResponse)) {
+      singleResponse = { ok: false, error: 'No response from the extension. Try again.' };
     }
 
     // Body may have been reparented while we waited on the LLM. Pick a
@@ -210,9 +265,19 @@ function wireTarget(
       if (button.element.isConnected) button.focus();
     };
 
+    const activeResponse = useThread ? threadResponse! : singleResponse!;
+    const errorPayload = !activeResponse.ok
+      ? buildErrorPayload(activeResponse, dismiss)
+      : undefined;
+
     const panel = createPanel({
-      ...(response.ok ? { summary: response.summary } : {}),
-      ...(response.ok ? {} : { error: buildErrorPayload(response, dismiss) }),
+      ...(useThread && activeResponse.ok
+        ? { thread: (activeResponse as { thread: ThreadSummary }).thread }
+        : {}),
+      ...(!useThread && activeResponse.ok
+        ? { summary: (activeResponse as { summary: Summary }).summary }
+        : {}),
+      ...(errorPayload ? { error: errorPayload } : {}),
       onDismiss: dismiss,
     });
     decoratePanel?.(panel.element);

--- a/apps/extension/src/shared/messages.ts
+++ b/apps/extension/src/shared/messages.ts
@@ -1,12 +1,18 @@
-import type { DefluffErrorCode, Summary } from '@defluff/core';
+import type { DefluffErrorCode, Summary, ThreadMessage, ThreadSummary } from '@defluff/core';
 
 export const MSG_SUMMARIZE = 'summarize' as const;
+export const MSG_SUMMARIZE_THREAD = 'summarize_thread' as const;
 export const MSG_TRIGGER_ACTIVE = 'trigger_active' as const;
 export const MSG_OPEN_OPTIONS = 'open_options' as const;
 
 export interface SummarizeRequest {
   type: typeof MSG_SUMMARIZE;
   text: string;
+}
+
+export interface SummarizeThreadRequest {
+  type: typeof MSG_SUMMARIZE_THREAD;
+  messages: ThreadMessage[];
 }
 
 export interface TriggerActiveRequest {
@@ -17,8 +23,16 @@ export interface OpenOptionsRequest {
   type: typeof MSG_OPEN_OPTIONS;
 }
 
-export type AppRequest = SummarizeRequest | TriggerActiveRequest | OpenOptionsRequest;
+export type AppRequest =
+  | SummarizeRequest
+  | SummarizeThreadRequest
+  | TriggerActiveRequest
+  | OpenOptionsRequest;
 
 export type SummarizeResponse =
   | { ok: true; summary: Summary }
+  | { ok: false; error: string; code?: DefluffErrorCode };
+
+export type SummarizeThreadResponse =
+  | { ok: true; thread: ThreadSummary }
   | { ok: false; error: string; code?: DefluffErrorCode };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,14 +7,19 @@ export {
 export type { ProviderConfigInput } from './config.js';
 export { DefluffError } from './errors.js';
 export type { DefluffErrorCode } from './errors.js';
-export { parseBullets, parseSummary } from './parse.js';
-export { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
+export { parseBullets, parseSummary, parseThreadSummary } from './parse.js';
+export {
+  buildThreadUserPrompt,
+  buildUserPrompt,
+  SYSTEM_PROMPT,
+  THREAD_SYSTEM_PROMPT,
+} from './prompt.js';
 export {
   PROVIDER_DEFAULT_MODELS,
   PROVIDER_KINDS,
   PROVIDER_LABELS,
 } from './providers/index.js';
-export { summarize } from './summarize.js';
+export { summarize, summarizeThread } from './summarize.js';
 export { toUserError } from './user-errors.js';
 export type { UserError, UserErrorAction } from './user-errors.js';
 export {
@@ -39,5 +44,11 @@ export type {
   ProviderRunArgs,
   Summary,
   SummarizeOptions,
+  SummarizeThreadOptions,
+  ThreadAction,
+  ThreadMessage,
+  ThreadMessageSummary,
+  ThreadSummary,
+  ThreadVerdict,
   Verdict,
 } from './types.js';

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -1,4 +1,12 @@
-import type { Authored, Summary, Verdict } from './types.js';
+import type {
+  Authored,
+  Summary,
+  ThreadAction,
+  ThreadMessageSummary,
+  ThreadSummary,
+  ThreadVerdict,
+  Verdict,
+} from './types.js';
 
 const BULLET_PATTERNS: readonly RegExp[] = [
   /^[-*•·]\s+(.+)$/,
@@ -168,4 +176,220 @@ function stripQuotes(s: string): string {
     .replace(/^["'“‘«]\s*/, '')
     .replace(/\s*["'”’»]$/, '')
     .trim();
+}
+
+const THREAD_VERDICT_MAP: Record<string, ThreadVerdict> = {
+  LEGIT: 'legit',
+  MIXED: 'mixed',
+  SCAM: 'scam',
+};
+
+/**
+ * Parse a thread-mode model response into a structured ThreadSummary.
+ *
+ * Input shape (authored by `THREAD_SYSTEM_PROMPT`):
+ *   <message block 1>
+ *   ===
+ *   <message block 2>
+ *   ===
+ *   Thread: ... — ...
+ *   Actions:
+ *   - ...: ...
+ *
+ * Each message block starts with a "Sender — timestamp" header followed by
+ * the same Authored/Prompt/Verdict/bullets shape parsed by parseSummary.
+ * The thread tail is identified by the "Thread:" line; anything after it
+ * up to an "Actions:" header is the verdict; anything after "Actions:" is
+ * the action list.
+ *
+ * The parser is lenient — if the model drops the === separators, it falls
+ * back to splitting on blank lines before a Sender-header-shaped line. If
+ * the Thread line is missing, threadVerdict stays undefined and the caller
+ * renders whatever messages it could extract.
+ */
+export function parseThreadSummary(raw: string): ThreadSummary {
+  const normalized = raw.replace(/\r\n/g, '\n').trim();
+  const blocks = splitThreadBlocks(normalized);
+
+  const messages: ThreadMessageSummary[] = [];
+  let threadVerdict: ThreadVerdict | undefined;
+  let threadVerdictReason: string | undefined;
+  const actions: ThreadAction[] = [];
+
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (!trimmed) continue;
+
+    if (isThreadTailBlock(trimmed)) {
+      const tail = parseThreadTail(trimmed);
+      if (tail.threadVerdict) threadVerdict = tail.threadVerdict;
+      if (tail.threadVerdictReason) threadVerdictReason = tail.threadVerdictReason;
+      actions.push(...tail.actions);
+      continue;
+    }
+
+    const message = parseMessageBlock(trimmed);
+    if (message) messages.push(message);
+  }
+
+  const out: ThreadSummary = { messages, actions };
+  if (threadVerdict) out.threadVerdict = threadVerdict;
+  if (threadVerdictReason) out.threadVerdictReason = threadVerdictReason;
+  return out;
+}
+
+function splitThreadBlocks(raw: string): string[] {
+  // Primary: === on its own line. Accept 3+ equals for leniency.
+  if (/^={3,}$/m.test(raw)) {
+    return raw.split(/^={3,}$/m);
+  }
+  // Fallback: split on blank lines that precede either a sender-header or
+  // the thread tail. This mostly catches drift where the model forgot the
+  // separators but kept the block structure.
+  const parts: string[] = [];
+  let current: string[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    const startsNewBlock =
+      current.length > 0 &&
+      current[current.length - 1]?.trim() === '' &&
+      (looksLikeSenderHeader(trimmed) || /^Thread\s*:/i.test(trimmed));
+    if (startsNewBlock) {
+      parts.push(current.join('\n'));
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) parts.push(current.join('\n'));
+  return parts.length > 1 ? parts : [raw];
+}
+
+function looksLikeSenderHeader(line: string): boolean {
+  if (!line) return false;
+  // "Sender — timestamp", "[2] Sender · timestamp", or variants. The key
+  // signal is that it's NOT a known label line (Authored/Prompt/Verdict/-).
+  if (/^(authored|prompt|verdict|thread|actions?)\s*[:\-—]/i.test(line)) return false;
+  if (line.startsWith('-') || line.startsWith('*')) return false;
+  // Sender and timestamp separated by — / - / · / :. At least some
+  // non-empty left-hand side with at least one letter.
+  return /[A-Za-zÀ-ÿ]/.test(line) && /[—\-·:]/.test(line);
+}
+
+function isThreadTailBlock(block: string): boolean {
+  return /^\s*Thread\s*[:\-—]/im.test(block);
+}
+
+interface ThreadTailParsed {
+  threadVerdict?: ThreadVerdict;
+  threadVerdictReason?: string;
+  actions: ThreadAction[];
+}
+
+function parseThreadTail(block: string): ThreadTailParsed {
+  const lines = block.split('\n');
+  const out: ThreadTailParsed = { actions: [] };
+  let inActions = false;
+  for (const raw of lines) {
+    const line = raw.replace(/\*\*/g, '').replace(/__/g, '').trim();
+    if (!line) continue;
+
+    if (!inActions) {
+      const threadMatch = /^thread\s*[:\-—]\s*(.+)$/i.exec(line);
+      if (threadMatch && threadMatch[1]) {
+        const parsed = extractThreadVerdict(threadMatch[1].trim());
+        if (parsed) {
+          out.threadVerdict = parsed.verdict;
+          if (parsed.reason) out.threadVerdictReason = parsed.reason;
+        }
+        continue;
+      }
+      if (/^actions?\s*[:\-—]?\s*$/i.test(line)) {
+        inActions = true;
+        continue;
+      }
+    }
+
+    if (inActions) {
+      const action = extractActionLine(line);
+      if (action) out.actions.push(action);
+    }
+  }
+  return out;
+}
+
+function extractThreadVerdict(
+  rest: string,
+): { verdict: ThreadVerdict; reason?: string } | undefined {
+  const upper = rest.toUpperCase();
+  for (const key of ['LEGIT', 'MIXED', 'SCAM']) {
+    if (!upper.startsWith(key)) continue;
+    const boundary = upper.charAt(key.length);
+    if (boundary !== '' && /[A-Z0-9]/.test(boundary)) continue;
+    const verdict = THREAD_VERDICT_MAP[key];
+    if (!verdict) continue;
+    const reason = rest.slice(key.length).replace(/^[\s—–\-:,.;]+/, '').trim();
+    return reason ? { verdict, reason } : { verdict };
+  }
+  return undefined;
+}
+
+function extractActionLine(line: string): ThreadAction | undefined {
+  // "- Alice: approve finalized vendor list"
+  const match = /^[-*•·]\s+(.+)$/.exec(line);
+  if (!match || !match[1]) return undefined;
+  const content = match[1].trim();
+  // "Alice: do the thing". Allow em-dash and en-dash as the separator too.
+  const splitMatch = /^([^:—–]{1,40})\s*[:\-—–]\s*(.+)$/.exec(content);
+  if (!splitMatch || !splitMatch[1] || !splitMatch[2]) return undefined;
+  return { who: splitMatch[1].trim(), action: splitMatch[2].trim() };
+}
+
+function parseMessageBlock(block: string): ThreadMessageSummary | undefined {
+  const lines = block.split('\n');
+  let header: string | undefined;
+  let headerIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    if (rawLine === undefined) continue;
+    const line = rawLine.replace(/\*\*/g, '').replace(/__/g, '').trim();
+    if (!line) continue;
+    if (looksLikeSenderHeader(line)) {
+      header = line;
+      headerIndex = i;
+      break;
+    }
+    // If the first non-empty line is already an Authored/Verdict/Prompt
+    // line, there is no sender header — treat the whole block as the body.
+    if (/^(authored|prompt|verdict)\s*[:\-—]/i.test(line)) break;
+  }
+
+  const body = (headerIndex >= 0 ? lines.slice(headerIndex + 1) : lines).join('\n');
+  const summary = parseSummary(body);
+  const hasAnySignal =
+    !!summary.authored ||
+    !!summary.reversedPrompt ||
+    !!summary.verdict ||
+    summary.bullets.length > 0;
+  if (!hasAnySignal && !header) return undefined;
+
+  const out: ThreadMessageSummary = { summary };
+  if (header) {
+    const parsed = parseSenderHeader(header);
+    if (parsed.sender) out.sender = parsed.sender;
+    if (parsed.timestamp) out.timestamp = parsed.timestamp;
+  }
+  return out;
+}
+
+function parseSenderHeader(line: string): { sender?: string; timestamp?: string } {
+  // Strip a leading "[1] " marker if the model echoed our user-prompt
+  // numbering back at us.
+  const stripped = line.replace(/^\[\d+\]\s*/, '');
+  // Split on the first of em-dash / en-dash / " · " / " - " / " : ".
+  const match = /^([^—–·:]+?)\s*[—–·:\-]\s*(.+)$/.exec(stripped);
+  if (match && match[1] && match[2]) {
+    return { sender: match[1].trim(), timestamp: match[2].trim() };
+  }
+  return stripped ? { sender: stripped.trim() } : {};
 }

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -122,3 +122,110 @@ export const SYSTEM_PROMPT = [
 export function buildUserPrompt(emailText: string): string {
   return `<email>\n${emailText.trim()}\n</email>`;
 }
+
+/**
+ * Thread-mode prompt. Keeps the single-message framing for EACH message
+ * (authored / optional prompt / verdict / bullets), then adds a thread-level
+ * verdict line + an Actions list. The thread-level verdict is the whole
+ * point — it's how the tool catches progressive-reveal scams, where each
+ * individual message looks fine but the sequence is a well-known pattern
+ * (fake recruiter → calendly + wallet ask; benign vendor chat → changed
+ * banking details; benign reconnect → trading-platform pitch).
+ *
+ * The literal "===" separator between message blocks is load-bearing for
+ * the parser. Keep it.
+ */
+export const THREAD_SYSTEM_PROMPT = [
+  'You are an AI-reversal tool. You are reading an email or messaging',
+  'thread — multiple messages in the same conversation. For EVERY message,',
+  'in order:',
+  '  (1) decide who authored it — AI, AI-assisted, or human;',
+  '  (2) if an AI was involved, guess the prompt the sender gave it;',
+  '  (3) classify how much attention it deserves',
+  '      (ACTIONABLE / RESPONSE-NEEDED / FYI / NOISE);',
+  '  (4) extract the real intent as 1-5 bullets.',
+  '',
+  'Then, after all per-message blocks, emit a THREAD VERDICT that considers',
+  'the messages together — this is where progressive-reveal scams get',
+  'caught. Then emit an ACTIONS list.',
+  '',
+  'Output EXACTLY in this structure. Separate EACH message block with a',
+  'line that is exactly "===" on its own. The final "===" sits between the',
+  'last message block and the thread tail (Thread: line + Actions section).',
+  '',
+  '[Sender] — [timestamp]',
+  'Authored: [AI | AI-assisted | human] — [reasoning, max 15 words]',
+  'Prompt: "[imperative — OMIT this entire line if Authored is human]"',
+  'Verdict: [ACTIONABLE | RESPONSE-NEEDED | FYI | NOISE] — [reason, max 15 words]',
+  '',
+  '- bullet',
+  '- bullet',
+  '',
+  '===',
+  '',
+  '(repeat the block above for every message in order)',
+  '',
+  '===',
+  '',
+  'Thread: [LEGIT | MIXED | SCAM — <named pattern>] — [one-sentence reason, max 20 words]',
+  '',
+  'Actions:',
+  '- [Sender]: [what they need to do, or "—" if nothing]',
+  '- [Sender]: [what they need to do, or "—" if nothing]',
+  '',
+  'Thread-verdict classification:',
+  '- LEGIT — a real conversation between real parties. No thread-level',
+  '  concern beyond whatever individual verdicts say.',
+  '- MIXED — mostly legit, but one or more messages are NOISE (e.g., a',
+  '  stray promotional reply in an otherwise real thread).',
+  '- SCAM — the messages form a scam progression across the thread. Name',
+  '  the specific pattern in the reason:',
+  '    * "fake recruiter → calendly + wallet" — benign-looking recruiter',
+  '      intro followed by a push to an external call (Calendly, Telegram,',
+  '      WhatsApp) + wallet / KYC / token / smart-contract ask.',
+  '    * "invoice fraud / BEC" — benign vendor chat pivots to a',
+  '      changed-banking-details ask or an urgent payment redirect.',
+  '    * "fake interview → credential harvest" — benign interview intro',
+  '      pivots to a take-home that requires access to the reader\'s',
+  '      systems, keys, or production credentials.',
+  '    * "crypto / MLM pitch" — benign reconnect or networking message',
+  '      pivots to a trading / passive-income / token-launch pitch.',
+  '    * "romance / investment" — long slow-build private conversation',
+  '      that eventually requests money or a shared wallet.',
+  '',
+  'Per-message rules (SAME as single-message output):',
+  '- Mirror the input language for the Authored reasoning, Prompt quote,',
+  '  Verdict reason, and every bullet. Keep literal labels English.',
+  '- Omit the Prompt line entirely when Authored is human.',
+  '- Bullets state content, not sender behavior. No meta-labels like',
+  '  "Bullet:" or "Point:". Preserve numbers, dates, names, amounts.',
+  '- Strip pleasantries, corporate jargon, AI-generated padding.',
+  '',
+  'Thread-tail rules:',
+  '- The Thread: line is REQUIRED. Emit it even for obvious LEGIT threads.',
+  '- Actions: is OPTIONAL. Omit the entire section (header + bullets) when',
+  '  neither party has anything to do. Never emit placeholder entries like',
+  '  "Actions: none" — absence is absence.',
+  '- Do not add conversational filler before, between, or after the',
+  '  required lines.',
+].join('\n');
+
+/**
+ * Serialize a list of ThreadMessage into a user-prompt payload. Each message
+ * is numbered for deterministic counting; unknown sender/timestamp fall back
+ * to "unknown" rather than being omitted, so the block header shape stays
+ * stable for the model.
+ */
+export function buildThreadUserPrompt(
+  messages: readonly { sender?: string; timestamp?: string; body: string }[],
+): string {
+  const blocks = messages.map((msg, index) => {
+    const sender = (msg.sender ?? 'unknown').trim() || 'unknown';
+    const timestamp = (msg.timestamp ?? 'unknown').trim() || 'unknown';
+    return [
+      `[${index + 1}] ${sender} · ${timestamp}`,
+      msg.body.trim(),
+    ].join('\n');
+  });
+  return `<thread>\n${blocks.join('\n\n---\n\n')}\n</thread>`;
+}

--- a/packages/core/src/summarize.ts
+++ b/packages/core/src/summarize.ts
@@ -1,13 +1,25 @@
 import { DefluffError } from './errors.js';
-import { parseSummary } from './parse.js';
-import { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
+import { parseSummary, parseThreadSummary } from './parse.js';
+import {
+  buildThreadUserPrompt,
+  buildUserPrompt,
+  SYSTEM_PROMPT,
+  THREAD_SYSTEM_PROMPT,
+} from './prompt.js';
 import {
   anthropicAdapter,
   geminiAdapter,
   openaiAdapter,
   openaiCompatibleAdapter,
 } from './providers/index.js';
-import type { ProviderConfig, ProviderRunArgs, Summary, SummarizeOptions } from './types.js';
+import type {
+  ProviderConfig,
+  ProviderRunArgs,
+  Summary,
+  SummarizeOptions,
+  SummarizeThreadOptions,
+  ThreadSummary,
+} from './types.js';
 
 export async function summarize(opts: SummarizeOptions): Promise<Summary> {
   const { text, provider, signal } = opts;
@@ -29,6 +41,45 @@ export async function summarize(opts: SummarizeOptions): Promise<Summary> {
     });
   }
   return summary;
+}
+
+/**
+ * Thread-mode summary. Takes an ordered list of messages (sender, timestamp,
+ * body) and returns a per-message summary list plus a thread-level verdict
+ * + actions. The thread-level verdict is where progressive-reveal scams
+ * get caught — patterns that are only visible when the whole conversation
+ * is considered together.
+ *
+ * Throws the same errors as summarize() for empty input and a new
+ * `no_bullets` case if the model returned zero parseable messages.
+ */
+export async function summarizeThread(
+  opts: SummarizeThreadOptions,
+): Promise<ThreadSummary> {
+  const { messages, provider, signal } = opts;
+  if (messages.length === 0) {
+    throw new DefluffError('bad_request', 'Thread has no messages.');
+  }
+  if (!messages.some((m) => m.body.trim().length > 0)) {
+    throw new DefluffError('bad_request', 'Thread has no non-empty messages.');
+  }
+
+  const args: ProviderRunArgs = {
+    systemPrompt: THREAD_SYSTEM_PROMPT,
+    userPrompt: buildThreadUserPrompt(messages),
+    ...(signal ? { signal } : {}),
+  };
+
+  const raw = await dispatchProvider(provider, args);
+  const thread = parseThreadSummary(raw);
+  if (thread.messages.length === 0) {
+    throw new DefluffError(
+      'no_bullets',
+      'Provider returned a thread with no parseable messages.',
+      { detail: { raw } },
+    );
+  }
+  return thread;
 }
 
 function dispatchProvider(provider: ProviderConfig, args: ProviderRunArgs): Promise<string> {

--- a/packages/core/src/thread.test.ts
+++ b/packages/core/src/thread.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefluffError } from './errors.js';
+import { parseThreadSummary } from './parse.js';
+import { buildThreadUserPrompt } from './prompt.js';
+import { summarizeThread } from './summarize.js';
+
+function mockFetchOnce(status: number, payload: unknown): void {
+  const response = new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
+}
+
+describe('buildThreadUserPrompt', () => {
+  it('numbers messages and falls back to "unknown" for missing sender / timestamp', () => {
+    const prompt = buildThreadUserPrompt([
+      { sender: 'Alice', timestamp: 'Tue 10:14', body: 'Need vendor list.' },
+      { body: '  Sent draft.  ' },
+    ]);
+    expect(prompt).toContain('[1] Alice · Tue 10:14');
+    expect(prompt).toContain('Need vendor list.');
+    expect(prompt).toContain('[2] unknown · unknown');
+    expect(prompt).toContain('Sent draft.');
+    expect(prompt.startsWith('<thread>')).toBe(true);
+    expect(prompt.endsWith('</thread>')).toBe(true);
+  });
+});
+
+describe('parseThreadSummary', () => {
+  it('parses a three-message scam progression with SCAM thread verdict', () => {
+    const raw = [
+      'Laycee — Mon 10:14',
+      'Authored: AI — Web3 kitchen-sink pitch, formulaic opener, zero specifics',
+      'Prompt: "Send a cold LinkedIn recruiter pitch for a CTO role at a Web3 project."',
+      'Verdict: NOISE — likely fake recruiter',
+      '',
+      '- CTO OR Strategic Advisor offered to a stranger — "any title you\'ll respond to" bait.',
+      '- AjunaVerse / ajuna.io — Web3 kitchen sink, no stage or funding detail.',
+      '',
+      '===',
+      '',
+      'Marijus — Mon 11:03',
+      'Authored: human — short polite hedge',
+      'Verdict: RESPONSE-NEEDED — asked a clarifying question',
+      '',
+      '- Asked what specifically the role entails',
+      '',
+      '===',
+      '',
+      'Laycee — Mon 14:22',
+      'Authored: AI — Calendly drop, smart-contract framing',
+      'Prompt: "Push the recipient to book a Calendly and mention our smart-contract platform."',
+      'Verdict: NOISE — likely phishing via Calendly',
+      '',
+      '- Pushed to book calendly.com/laycee-ajuna for a 30-minute call.',
+      '- Mentioned wallet connection required to preview the smart contract.',
+      '',
+      '===',
+      '',
+      'Thread: SCAM — fake recruiter → calendly + wallet',
+      '',
+      'Actions:',
+      '- Marijus: do not book the call; block sender.',
+      '- Laycee: —',
+    ].join('\n');
+
+    const thread = parseThreadSummary(raw);
+    expect(thread.messages).toHaveLength(3);
+    expect(thread.messages[0]?.sender).toBe('Laycee');
+    expect(thread.messages[0]?.summary.authored).toBe('ai');
+    expect(thread.messages[0]?.summary.verdict).toBe('noise');
+    expect(thread.messages[1]?.sender).toBe('Marijus');
+    expect(thread.messages[1]?.summary.authored).toBe('human');
+    expect(thread.messages[1]?.summary.reversedPrompt).toBeUndefined();
+    expect(thread.messages[2]?.summary.verdict).toBe('noise');
+    expect(thread.threadVerdict).toBe('scam');
+    expect(thread.threadVerdictReason).toMatch(/recruiter.*calendly.*wallet/);
+    expect(thread.actions).toHaveLength(2);
+    expect(thread.actions[0]).toEqual({
+      who: 'Marijus',
+      action: 'do not book the call; block sender.',
+    });
+    expect(thread.actions[1]?.action).toBe('—');
+  });
+
+  it('parses a LEGIT two-message thread with no Actions section', () => {
+    const raw = [
+      'Alice — Tue 10:14',
+      'Authored: human — terse reply-on-top, named Bob',
+      'Verdict: RESPONSE-NEEDED — waiting on vendor list',
+      '',
+      '- Q3 budget capped at $50k',
+      '- Need finalized vendor list by Friday',
+      '',
+      '===',
+      '',
+      'Bob — Tue 14:02',
+      'Authored: AI-assisted — polished prose around concrete vendor names',
+      'Prompt: "Confirm vendors A and B and explain the C decline."',
+      'Verdict: ACTIONABLE — deliverable coming Thursday',
+      '',
+      '- Vendor A and B confirmed',
+      '- Contract draft Thursday',
+      '',
+      '===',
+      '',
+      'Thread: LEGIT — real internal coordination on vendor sign-off',
+    ].join('\n');
+
+    const thread = parseThreadSummary(raw);
+    expect(thread.messages).toHaveLength(2);
+    expect(thread.threadVerdict).toBe('legit');
+    expect(thread.threadVerdictReason).toMatch(/vendor sign-off/);
+    expect(thread.actions).toEqual([]);
+  });
+
+  it('tolerates a missing === separator by falling back on sender-header detection', () => {
+    const raw = [
+      'Alice — Tue 10:14',
+      'Authored: human — terse',
+      'Verdict: RESPONSE-NEEDED — waiting',
+      '',
+      '- Need the list',
+      '',
+      '',
+      'Bob — Tue 14:02',
+      'Authored: human — terse reply',
+      'Verdict: ACTIONABLE — will send Thursday',
+      '',
+      '- Thursday delivery',
+      '',
+      '',
+      'Thread: LEGIT — real internal chat',
+    ].join('\n');
+
+    const thread = parseThreadSummary(raw);
+    expect(thread.messages).toHaveLength(2);
+    expect(thread.threadVerdict).toBe('legit');
+  });
+
+  it('returns an empty-messages thread when the model emits only a Thread line', () => {
+    const raw = 'Thread: LEGIT — nothing to do';
+    const thread = parseThreadSummary(raw);
+    expect(thread.messages).toEqual([]);
+    expect(thread.threadVerdict).toBe('legit');
+  });
+});
+
+describe('summarizeThread', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('parses a three-message scam thread end-to-end through the OpenAI shape', async () => {
+    const modelResponse = [
+      'Laycee — Mon 10:14',
+      'Authored: AI — generic Web3 pitch',
+      'Prompt: "Cold LinkedIn recruiter pitch for a CTO role."',
+      'Verdict: NOISE — likely fake recruiter',
+      '',
+      '- Generic Web3 pitch, no specifics',
+      '',
+      '===',
+      '',
+      'Laycee — Mon 14:22',
+      'Authored: AI — calendly drop',
+      'Prompt: "Push recipient to book a calendly and connect wallet."',
+      'Verdict: NOISE — likely phishing',
+      '',
+      '- Calendly + wallet-connect ask',
+      '',
+      '===',
+      '',
+      'Thread: SCAM — fake recruiter → calendly + wallet',
+      '',
+      'Actions:',
+      '- You: do not respond; block sender.',
+    ].join('\n');
+
+    mockFetchOnce(200, {
+      choices: [{ message: { content: modelResponse } }],
+    });
+
+    const result = await summarizeThread({
+      messages: [
+        { sender: 'Laycee', timestamp: 'Mon 10:14', body: 'Exciting opportunity at ajuna.io...' },
+        { sender: 'Laycee', timestamp: 'Mon 14:22', body: 'Book a time: calendly.com/...' },
+      ],
+      provider: { kind: 'openai', apiKey: 'sk-test' },
+    });
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.threadVerdict).toBe('scam');
+    expect(result.threadVerdictReason).toMatch(/calendly/i);
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0]?.who).toBe('You');
+  });
+
+  it('rejects an empty message list', async () => {
+    await expect(
+      summarizeThread({ messages: [], provider: { kind: 'openai', apiKey: 'sk-test' } }),
+    ).rejects.toMatchObject({ code: 'bad_request' });
+  });
+
+  it('rejects a thread with only whitespace bodies', async () => {
+    await expect(
+      summarizeThread({
+        messages: [{ body: '  ' }, { body: '\n\n' }],
+        provider: { kind: 'openai', apiKey: 'sk-test' },
+      }),
+    ).rejects.toBeInstanceOf(DefluffError);
+  });
+
+  it('throws no_bullets when the response parses to zero messages and no thread verdict', async () => {
+    mockFetchOnce(200, {
+      choices: [{ message: { content: 'I cannot summarize this thread.' } }],
+    });
+
+    await expect(
+      summarizeThread({
+        messages: [{ body: 'Hello.' }],
+        provider: { kind: 'openai', apiKey: 'sk-test' },
+      }),
+    ).rejects.toMatchObject({ code: 'no_bullets' });
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,6 +78,55 @@ export interface SummarizeOptions {
   signal?: AbortSignal;
 }
 
+/**
+ * A single message in a thread. Sender and timestamp are best-effort — the
+ * DOM scrape in the extension may miss them on collapsed runs or reply-all
+ * blocks. The body is always required; without it there is nothing to
+ * summarize.
+ */
+export interface ThreadMessage {
+  sender?: string;
+  timestamp?: string;
+  body: string;
+}
+
+/**
+ * Thread-level verdict. Distinct from the per-message Verdict space
+ * (ACTIONABLE / RESPONSE-NEEDED / FYI / NOISE) because it describes the
+ * conversation as a whole — in particular, scam progressions where
+ * individual messages look fine but the sequence is not.
+ */
+export type ThreadVerdict = 'legit' | 'mixed' | 'scam';
+
+export interface ThreadMessageSummary {
+  sender?: string;
+  timestamp?: string;
+  summary: Summary;
+}
+
+export interface ThreadAction {
+  /** The person responsible. Free-form — "Alice", "You", "Both", "—". */
+  who: string;
+  /** What that person needs to do. "—" when nothing is required. */
+  action: string;
+}
+
+export interface ThreadSummary {
+  messages: ThreadMessageSummary[];
+  /** LEGIT / MIXED / SCAM at the thread level. Optional when the model did not emit one. */
+  threadVerdict?: ThreadVerdict;
+  /** One-sentence reason, naming the scam pattern if applicable. */
+  threadVerdictReason?: string;
+  /** Per-person action list from the model. May be empty. */
+  actions: ThreadAction[];
+}
+
+export interface SummarizeThreadOptions {
+  messages: ThreadMessage[];
+  provider: ProviderConfig;
+  signal?: AbortSignal;
+}
+
 export interface ProviderRunArgs {
   systemPrompt: string;
   userPrompt: string;


### PR DESCRIPTION
## The problem

Single-message mode can't catch the real LinkedIn recruiter pattern:

> **Message 1 (Laycee):** *"I'm reaching out to share an exciting opportunity at AjunaVerse, a next-generation Web3 platform..."*
>
> **Message 3 (Laycee):** *"Book a time: calendly.com/laycee-ajuna — we'll connect your wallet during the call to preview the smart contract."*

Each message in isolation reads as generic recruiter spam. **The sequence is the scam.** Thread mode catches the progression.

## What this ships

Thread mode on LinkedIn only. Gmail is a follow-up PR (its DOM is more fragmented between conversation and message view).

**How it works:** when the user clicks any LinkedIn message's De-Fluff button, the host walks up to the conversation pane, collects `{sender, timestamp, body}` per message (capped at the last 8), and sends the whole thing to the model via a new `SUMMARIZE_THREAD` path. The model returns per-message authored/verdict/bullets PLUS a thread-level verdict that names the scam pattern. If only one message is found, the host falls back to single-message mode transparently — no UI change, no extra click.

## Thread-verdict vocabulary

| Verdict | When |
|---|---|
| **LEGIT** | Real conversation between real parties. |
| **MIXED** | Mostly legit, but one or more messages are NOISE (e.g., stray promo reply). |
| **SCAM** | The messages form a progression. The reason names the pattern. |

**Named scam progressions:**
- `fake recruiter → calendly + wallet`
- `invoice fraud / BEC`
- `fake interview → credential harvest`
- `crypto / MLM pitch`
- `romance / investment`

## Core (`packages/core`)

- New types: \`ThreadMessage\`, \`ThreadSummary\`, \`ThreadMessageSummary\`, \`ThreadAction\`, \`ThreadVerdict\`, \`SummarizeThreadOptions\`.
- New \`THREAD_SYSTEM_PROMPT\` mirrors per-message rules from the existing \`SYSTEM_PROMPT\` (Authored line, language mirroring, NOISE scam-pattern naming) and adds the thread tail. \`===\` is the block separator.
- \`parseThreadSummary\` reuses \`parseSummary\` per message block; parses the tail for \`Thread:\` + \`Actions:\`.
- \`summarizeThread\` — parallel entry point to \`summarize\`, same error shape.
- **9 new tests** (parse.test has 17, thread.test has 9 covering scam progression, LEGIT+no-actions, missing \`===\` fallback, empty+Thread-only, end-to-end OpenAI shape, input validation).

## Extension

- \`shared/messages.ts\`: new \`MSG_SUMMARIZE_THREAD\` + \`SummarizeThreadResponse\`.
- \`background.ts\`: dispatches thread requests to \`summarizeThread\`.
- \`hosts/linkedin.ts\`: \`extractThread\` walker — finds \`msg-s-message-list\` ancestor, collects \`.msg-s-event-listitem\` entries with sender/timestamp, carries sender forward across collapsed runs, capped at 8. Defensive fallbacks everywhere; failure degrades to single-message mode, never surfaces as error.
- \`wireHost.ts\`: \`extractThread\` is a new optional strategy field. Dispatches thread-mode only when >1 non-empty messages. Gmail/Outlook unaffected.
- \`panel.ts\`: renders thread-verdict strip first (SCAM paints panel border red), then per-message blocks reusing single-message authored/verdict/bullet renderers, then actions list.
- \`styles.ts\`: thread-specific rules using existing CSS vars — dark mode and Gmail-adjacent chrome unchanged.

## Constraints honored

- **Zero new servers.** Still BYOK, still zero retention. The LLM gets more context per click but it still goes straight to the user's provider.
- **Cap at 8 messages** keeps token cost predictable — scam reveals are always in the tail.
- **DOM-scrape is defensive** — every selector has a fallback, and the worst case is "single-message mode runs instead of thread mode."
- **Legacy responses still parse** — nothing breaks for users on older models that don't know the thread format (they'll never hit \`SUMMARIZE_THREAD\` because extraction is host-side).

## Test plan

- [x] \`pnpm --filter @defluff/core test\` — 49/49 (9 new thread tests)
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm --filter @defluff/extension build\` — clean
- [ ] Load unpacked extension, open a LinkedIn recruiter thread, click De-Fluff, confirm:
  - [ ] Thread verdict strip renders
  - [ ] Per-message blocks each show their own authored/verdict/bullets
  - [ ] Actions list renders when present, absent when model omits it
  - [ ] SCAM panel paints the left border red
- [ ] Smoke-test on a 1-message conversation to confirm it still single-message-falls-through
- [ ] Smoke-test on a 15+ message conversation to confirm 8-message truncation keeps the tail
- [ ] (Optional) Try with a real-world "AjunaVerse" / "Calendly + wallet" pattern if you've got one saved

## Follow-ups

- Gmail thread mode — next PR.
- Outlook thread mode — further out.
- Sync the SKILL.md files to describe the Thread: + Actions format (skill thread output is currently prose-level; extension output is more structured). Minor sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)