### PR TITLE
feat(errors): surface raw provider response in a collapsible details block

### DIFF
--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -18,6 +18,13 @@ export interface PanelController {
 export interface PanelError {
   title: string;
   explanation: string;
+  /**
+   * Raw provider response. Rendered as a collapsible "Provider response"
+   * block under the friendly explanation so developers can diagnose
+   * model-name typos, rate-limit wording, and other provider-specific
+   * signals that the preset explanation would otherwise hide.
+   */
+  details?: string;
   cta?: { label: string; onClick: () => void };
 }
 
@@ -111,6 +118,19 @@ function renderError(panel: HTMLElement, error: PanelError): void {
     const p = document.createElement('p');
     p.textContent = error.explanation;
     panel.appendChild(p);
+  }
+
+  if (error.details) {
+    const disclosure = document.createElement('details');
+    disclosure.className = 'df-error-details';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Provider response';
+    disclosure.appendChild(summary);
+    const body = document.createElement('pre');
+    body.className = 'df-error-details-body';
+    body.textContent = error.details;
+    disclosure.appendChild(body);
+    panel.appendChild(disclosure);
   }
 }
 

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -209,6 +209,39 @@ export const CONTENT_CSS = `
 .df-panel.df-error p { margin: 4px 0 0; color: var(--df-fg); font-size: 13px; }
 .df-panel .df-error-icon { font-size: 14px; }
 
+/* Collapsible provider-response block for debugging. Hidden behind a
+   disclosure so the normal case (friendly preset) stays clean, but one
+   click exposes the raw provider JSON so a developer can see exactly
+   why the request was rejected. */
+.df-error-details {
+  margin: 10px 0 0;
+  font-size: 12px;
+}
+.df-error-details summary {
+  cursor: pointer;
+  color: var(--df-muted);
+  user-select: none;
+  padding: 2px 0;
+}
+.df-error-details summary:hover { color: var(--df-fg); }
+.df-error-details summary:focus-visible { outline: 2px solid var(--df-accent); outline-offset: 2px; border-radius: 2px; }
+.df-error-details-body {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  line-height: 1.45;
+  background: var(--df-bg);
+  border: 1px solid var(--df-panel-border);
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--df-fg);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
 /* Screen-reader-only live region */
 .df-sr-only {
   position: absolute;

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -331,6 +331,7 @@ function buildErrorPayload(
 ): PanelError {
   const userError = toUserError(response.code, response.error);
   const base: PanelError = { title: userError.title, explanation: userError.explanation };
+  if (userError.details) base.details = userError.details;
   if (userError.action === 'configure') {
     base.cta = {
       label: 'Open settings',

--- a/apps/outlook-addin/src/taskpane/main.ts
+++ b/apps/outlook-addin/src/taskpane/main.ts
@@ -213,6 +213,19 @@ function renderError(err: unknown): void {
     pane.appendChild(p);
   }
 
+  if (userError.details) {
+    const disclosure = document.createElement('details');
+    disclosure.className = 'error-details';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Provider response';
+    disclosure.appendChild(summary);
+    const body = document.createElement('pre');
+    body.className = 'error-details-body';
+    body.textContent = userError.details;
+    disclosure.appendChild(body);
+    pane.appendChild(disclosure);
+  }
+
   if (userError.action === 'configure') {
     const btn = document.createElement('button');
     btn.type = 'button';

--- a/apps/outlook-addin/src/taskpane/styles.css
+++ b/apps/outlook-addin/src/taskpane/styles.css
@@ -215,4 +215,31 @@ button.link:hover { text-decoration: underline; background: none; color: var(--a
 .error p { margin: 0; }
 .error button { align-self: flex-start; margin-top: 4px; }
 
+/* Collapsible raw provider response for debugging — same shape as the
+   extension panel. Hidden behind a disclosure so the preset copy stays
+   tidy, one click exposes the provider JSON so a developer can see
+   exactly why a request was rejected. */
+.error-details { margin-top: 4px; font-size: 12px; }
+.error-details summary {
+  cursor: pointer;
+  color: var(--muted);
+  user-select: none;
+  padding: 2px 0;
+}
+.error-details summary:hover { color: var(--fg); }
+.error-details-body {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  line-height: 1.45;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+}
+
 .settings-link { margin-top: 14px; font-size: 13px; color: var(--muted); }

--- a/packages/core/src/user-errors.test.ts
+++ b/packages/core/src/user-errors.test.ts
@@ -24,5 +24,24 @@ describe('toUserError', () => {
   it('honors an explicit fallback message', () => {
     const err = toUserError(undefined, 'Custom fallback');
     expect(err.explanation).toBe('Custom fallback');
+    expect(err.details).toBeUndefined();
+  });
+
+  it('surfaces raw provider message as details when code is known', () => {
+    const err = toUserError(
+      'bad_request',
+      "The model 'gpt-5.4' does not exist or you do not have access to it.",
+    );
+    // Friendly preset is preserved so the user still gets a useful headline.
+    expect(err.title).toBe('The provider rejected the request');
+    // Raw provider message is kept alongside for developers.
+    expect(err.details).toBe(
+      "The model 'gpt-5.4' does not exist or you do not have access to it.",
+    );
+  });
+
+  it('omits details when the raw message duplicates the canned explanation', () => {
+    const err = toUserError('bad_request', 'The model name might be wrong. Check settings.');
+    expect(err.details).toBeUndefined();
   });
 });

--- a/packages/core/src/user-errors.ts
+++ b/packages/core/src/user-errors.ts
@@ -9,6 +9,14 @@ export interface UserError {
   explanation: string;
   /** Hints to the UI what kind of CTA to render. */
   action: UserErrorAction;
+  /**
+   * The raw provider response / error message, kept alongside the
+   * friendly title+explanation so the UI can expose it in a collapsible
+   * "Provider response" block. Useful for debugging model-name typos,
+   * rate-limit wording, and provider-specific error codes that the
+   * friendly preset would otherwise hide.
+   */
+  details?: string;
 }
 
 /**
@@ -17,13 +25,32 @@ export interface UserError {
  * `configure`, "Try again" for `retry`). The fallback message is only used
  * when an unknown code comes through — we try to surface something useful
  * even then.
+ *
+ * When a raw `message` is supplied AND the code is known, the message is
+ * kept as `details` so the panel can expose it to developers. For unknown
+ * codes the message is already used as the explanation, so it's not also
+ * duplicated into details.
  */
 export function toUserError(
   code: DefluffErrorCode | undefined,
-  fallback = 'Something went wrong. Try again.',
+  message?: string,
 ): UserError {
-  if (code && code in MESSAGES) return MESSAGES[code];
-  return { title: 'Something went wrong', explanation: fallback, action: 'retry' };
+  const preset = code && code in MESSAGES ? MESSAGES[code] : undefined;
+  if (preset) {
+    const trimmed = message?.trim();
+    // Only surface details when distinct from the canned explanation —
+    // otherwise the disclosure reveals the same sentence the user already
+    // sees, which just looks like clutter.
+    if (trimmed && trimmed !== preset.explanation) {
+      return { ...preset, details: trimmed };
+    }
+    return { ...preset };
+  }
+  return {
+    title: 'Something went wrong',
+    explanation: message ?? 'Something went wrong. Try again.',
+    action: 'retry',
+  };
 }
 
 const MESSAGES: Record<DefluffErrorCode, UserError> = {


### PR DESCRIPTION
## The gap

When you typed \`gpt-5.4\` as the model name and clicked De-Fluff, you got:

> ⚠ The provider rejected the request  
> The model name might be wrong. Check settings.

No way to see that OpenAI actually said \`The model 'gpt-5.4' does not exist or you do not have access to it.\` — the adapter captures that into \`DefluffError.message\`, but \`toUserError(code, message)\` was replacing it with the generic preset copy for known codes like \`bad_request\` and dropping the raw text.

Result: zero diagnostic info in the UI; you had to open DevTools and read console output.

## Fix

\`UserError\` gets an optional \`details?: string\` field that always carries the raw provider message alongside the friendly title+explanation. Both clients render it as a collapsible **Provider response** block under the explanation — preset copy stays tidy, one click exposes the raw body.

![shape]
> ⚠ The provider rejected the request  
> The model name might be wrong. Check settings.  
> ▸ Provider response  _(click to expand)_  
>
> \`\`\`  
> The model 'gpt-5.4' does not exist or you do not have access to it.  
> \`\`\`

Same shape in the Outlook taskpane.

## What changed

- **\`packages/core/src/user-errors.ts\`** — \`UserError.details\`, populated from the \`message\` arg when the code is known. Guarded against duplicating the preset explanation (which would render an empty-looking disclosure).
- **\`apps/extension/src/content/ui/panel.ts\`** + **\`styles.ts\`** — renders \`<details>\` with monospace body, scrollable, max-height 240px.
- **\`apps/outlook-addin/src/taskpane/main.ts\`** + **\`styles.css\`** — same shape.
- **\`apps/extension/src/content/ui/wireHost.ts\`** — plumbs \`userError.details\` into the \`PanelError\`.
- **2 new tests** on \`toUserError\`: verifies details populated from raw message with known code; verifies dedup when the raw message duplicates the preset explanation.

## Tests

- [x] \`pnpm --filter @defluff/core test\` — 53/53 pass (2 new)
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm --filter @defluff/extension build\` — clean
- [x] \`pnpm --filter @defluff/outlook-addin build\` — clean

## Test plan (manual)

- [ ] Load unpacked extension, set model to \`gpt-5.4\`, click De-Fluff on any email — confirm the **Provider response** disclosure expands to show OpenAI's actual error text
- [ ] Try with a deliberately bad API key — confirm \`401\` auth error shows the provider's message (OpenAI: \`Incorrect API key provided: ...\`) when expanded
- [ ] Try against Ollama pointing at a missing model — confirm the Ollama JSON body is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)