### PR TITLE
fix(openai): switch to max_completion_tokens + audit all provider bodies

### DIFF
--- a/packages/core/src/providers/bodies.test.ts
+++ b/packages/core/src/providers/bodies.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  anthropicAdapter,
+  geminiAdapter,
+  openaiAdapter,
+  openaiCompatibleAdapter,
+} from './index.js';
+
+/**
+ * Regression tests for request-body shape. The class of bug these guard
+ * against: "the provider added / removed / renamed a parameter and the
+ * adapter silently broke for that provider's newer models." Example:
+ * OpenAI's reasoning models (o1 / o3 / GPT-5) reject `max_tokens` and
+ * require `max_completion_tokens`; Ollama's OpenAI-compatible endpoint
+ * does NOT know `max_completion_tokens` and keeps `max_tokens`.
+ *
+ * Each test captures the outgoing fetch body and asserts on the keys
+ * that have historically moved between providers.
+ */
+
+function captureFetchBody(): { body: Record<string, unknown> | null } {
+  const captured: { body: Record<string, unknown> | null } = { body: null };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          // Shape that satisfies every adapter's success parser.
+          choices: [{ message: { content: 'Verdict: FYI — ok\n- a\n' } }],
+          content: [{ type: 'text', text: 'Verdict: FYI — ok\n- a\n' }],
+          candidates: [{ content: { parts: [{ text: 'Verdict: FYI — ok\n- a\n' }] } }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }),
+  );
+  return captured;
+}
+
+describe('provider request bodies', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('OpenAI sends max_completion_tokens (not max_tokens) — works on reasoning models', async () => {
+    const captured = captureFetchBody();
+    await openaiAdapter.run(
+      { kind: 'openai', apiKey: 'sk-test' },
+      { systemPrompt: 'sys', userPrompt: 'usr' },
+    );
+    expect(captured.body).toBeTruthy();
+    expect(captured.body).toHaveProperty('max_completion_tokens');
+    // Regression guard: reasoning models reject max_tokens with a 400.
+    expect(captured.body).not.toHaveProperty('max_tokens');
+    // Reasoning models count internal tokens against the budget, so the
+    // OpenAI path uses a higher value than generic Ollama endpoints.
+    expect(captured.body?.max_completion_tokens).toBeGreaterThanOrEqual(1024);
+  });
+
+  it('OpenAI-compatible (Ollama / LM Studio) keeps max_tokens', async () => {
+    const captured = captureFetchBody();
+    await openaiCompatibleAdapter.run(
+      {
+        kind: 'openai-compatible',
+        baseUrl: 'http://localhost:11434/v1',
+        model: 'llama3',
+      },
+      { systemPrompt: 'sys', userPrompt: 'usr' },
+    );
+    expect(captured.body).toBeTruthy();
+    // Ollama does NOT recognize max_completion_tokens (as of late 2025).
+    expect(captured.body).toHaveProperty('max_tokens');
+    expect(captured.body).not.toHaveProperty('max_completion_tokens');
+  });
+
+  it('Anthropic sends max_tokens (Messages API, unchanged across Claude 3.x–4.x)', async () => {
+    const captured = captureFetchBody();
+    await anthropicAdapter.run(
+      { kind: 'anthropic', apiKey: 'sk-ant-test' },
+      { systemPrompt: 'sys', userPrompt: 'usr' },
+    );
+    expect(captured.body).toBeTruthy();
+    expect(captured.body).toHaveProperty('max_tokens');
+    // Anthropic's Messages API has a flat system field, not chat-style.
+    expect(captured.body).toHaveProperty('system', 'sys');
+    expect(captured.body?.messages).toEqual([{ role: 'user', content: 'usr' }]);
+  });
+
+  it('Gemini sends generationConfig.maxOutputTokens (not top-level max_tokens)', async () => {
+    const captured = captureFetchBody();
+    await geminiAdapter.run(
+      { kind: 'gemini', apiKey: 'test-key' },
+      { systemPrompt: 'sys', userPrompt: 'usr' },
+    );
+    expect(captured.body).toBeTruthy();
+    expect(captured.body).not.toHaveProperty('max_tokens');
+    expect(captured.body).not.toHaveProperty('max_completion_tokens');
+    const config = captured.body?.generationConfig as
+      | { maxOutputTokens?: number }
+      | undefined;
+    expect(config?.maxOutputTokens).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/providers/openai-compatible.ts
+++ b/packages/core/src/providers/openai-compatible.ts
@@ -6,17 +6,55 @@ interface ChatCompletionsResponse {
   error?: { message?: string; type?: string };
 }
 
+/**
+ * Which token-limit key to put in the request body.
+ *
+ * - `max_tokens`             — the historical Chat Completions parameter.
+ *                              Still accepted by Ollama, LM Studio, LiteLLM
+ *                              proxies, most OpenAI-compatible gateways, and
+ *                              OpenAI's own non-reasoning models (gpt-4o,
+ *                              gpt-4o-mini, gpt-3.5-turbo, etc.).
+ * - `max_completion_tokens`  — the replacement OpenAI introduced with its
+ *                              reasoning models. OpenAI's o1 / o3 / GPT-5
+ *                              class REJECTS `max_tokens` with a 400 and
+ *                              requires this key. Older OpenAI models also
+ *                              accept it. Ollama and friends do NOT
+ *                              recognize it, so keep them on `max_tokens`.
+ */
+type TokenLimitKey = 'max_tokens' | 'max_completion_tokens';
+
 export const openaiCompatibleAdapter: ProviderAdapter<OpenAICompatibleConfig> = {
   async run(config, args) {
     return callOpenAICompatible(
-      { baseUrl: config.baseUrl, apiKey: config.apiKey, model: config.model },
+      {
+        baseUrl: config.baseUrl,
+        apiKey: config.apiKey,
+        model: config.model,
+      },
       args,
     );
   },
 };
 
 export async function callOpenAICompatible(
-  config: { baseUrl: string; apiKey?: string; model: string },
+  config: {
+    baseUrl: string;
+    apiKey?: string;
+    model: string;
+    /**
+     * Which token-limit key to send. Defaults to `max_tokens` — right for
+     * Ollama, LM Studio, and every generic OpenAI-compatible gateway.
+     * The OpenAI-branded adapter (providers/openai.ts) overrides to
+     * `max_completion_tokens` so its requests work on reasoning models.
+     */
+    tokenLimitKey?: TokenLimitKey;
+    /**
+     * How many tokens to allow. Reasoning models count internal chain-of-
+     * thought tokens against this budget, so the OpenAI adapter uses a
+     * higher value than generic OpenAI-compatible endpoints.
+     */
+    maxTokens?: number;
+  },
   args: ProviderRunArgs,
 ): Promise<string> {
   const url = `${config.baseUrl.replace(/\/+$/, '')}/chat/completions`;
@@ -25,9 +63,12 @@ export async function callOpenAICompatible(
     headers.authorization = `Bearer ${config.apiKey}`;
   }
 
+  const tokenLimitKey: TokenLimitKey = config.tokenLimitKey ?? 'max_tokens';
+  const tokenLimitValue = config.maxTokens ?? 512;
+
   const body = {
     model: config.model,
-    max_tokens: 512,
+    [tokenLimitKey]: tokenLimitValue,
     messages: [
       { role: 'system', content: args.systemPrompt },
       { role: 'user', content: args.userPrompt },

--- a/packages/core/src/providers/openai.ts
+++ b/packages/core/src/providers/openai.ts
@@ -4,13 +4,33 @@ import { callOpenAICompatible } from './openai-compatible.js';
 const DEFAULT_MODEL = 'gpt-4o-mini';
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 
+/**
+ * Token budget for OpenAI. Reasoning models (o1 / o3 / GPT-5 class)
+ * consume internal chain-of-thought tokens against this budget, so 512
+ * from the generic OpenAI-compatible default is too tight — the visible
+ * completion gets truncated after a few hundred reasoning tokens.
+ * 2048 gives comfortable headroom for both visible output (~300 tokens
+ * for our structured response) and up to ~1500 reasoning tokens on the
+ * short summarization task this prompt asks for.
+ */
+const OPENAI_MAX_COMPLETION_TOKENS = 2048;
+
 export const openaiAdapter: ProviderAdapter<OpenAIConfig> = {
   async run(config, args) {
+    // Use `max_completion_tokens` rather than `max_tokens`. Reasoning
+    // models (o1-preview, o1-mini, o3-mini, GPT-5 class) REJECT
+    // `max_tokens` outright with a 400; the replacement param works on
+    // those AND on older OpenAI models (gpt-4o, gpt-4o-mini, etc.), so
+    // one call shape covers the whole OpenAI fleet. Ollama and LM Studio
+    // don't recognize `max_completion_tokens` and stay on `max_tokens`
+    // via openai-compatible.ts's default.
     return callOpenAICompatible(
       {
         baseUrl: DEFAULT_BASE_URL,
         apiKey: config.apiKey,
         model: config.model ?? DEFAULT_MODEL,
+        tokenLimitKey: 'max_completion_tokens',
+        maxTokens: OPENAI_MAX_COMPLETION_TOKENS,
       },
       args,
     );


### PR DESCRIPTION
## What broke

Once the provider-response disclosure shipped (#36), it exposed the real reason for the \`gpt-5.4\` rejection — not a model name issue, a **parameter-shape** one:

> Unsupported parameter: \`'max_tokens'\` is not supported with this model. Use \`'max_completion_tokens'\` instead.

OpenAI's reasoning models (o1-preview, o1-mini, o3-mini, **GPT-5 class**) reject \`max_tokens\` outright with a 400. The adapter was sending \`max_tokens: 512\` to every OpenAI model, which worked for gpt-4o-mini and older but silently broke every reasoning-class model.

## Comprehensive provider audit

Before fixing OpenAI, I went through all four adapters to check for the same class of drift elsewhere:

| Adapter | Token-limit param | Status |
|---|---|---|
| **OpenAI** | \`max_tokens: 512\` | ❌ Broken on reasoning models |
| **OpenAI-compatible** (Ollama, LM Studio) | \`max_tokens: 512\` | ✅ Correct — these don't know \`max_completion_tokens\` |
| **Anthropic** | \`max_tokens: 512\` | ✅ Required by Messages API, stable across 3.x→4.x |
| **Gemini** | \`generationConfig.maxOutputTokens: 512\` | ✅ Stable across 2.x–2.5 |

Also checked: temperature (unset everywhere — good, reasoning models require default), response format / JSON mode (not used), streaming (not used), tools (not used). Nothing else currently at risk.

## Fix

Surgical split. Only the OpenAI-branded endpoint needs the new param.

**\`openai-compatible.ts\`** grows optional \`tokenLimitKey\` and \`maxTokens\` parameters:

- Defaults stay \`'max_tokens'\` / \`512\` — correct for Ollama, LM Studio, LiteLLM, and every generic OpenAI-compatible gateway.
- These gateways do NOT recognize \`max_completion_tokens\`, so keeping them on \`max_tokens\` is necessary, not just convenient.

**\`openai.ts\`** overrides to:

- \`tokenLimitKey: 'max_completion_tokens'\` — works on reasoning models AND older non-reasoning OpenAI models (gpt-4o, gpt-4o-mini, etc.), so one call shape covers the whole OpenAI fleet.
- \`maxTokens: 2048\` — load-bearing. Reasoning models consume internal chain-of-thought tokens against this budget; 512 truncates visible output after a few hundred thinking tokens. 2048 leaves ~1500 reasoning + ~300 visible output, which is comfortable for our structured response.

## Regression-guard tests

New \`packages/core/src/providers/bodies.test.ts\` — 4 tests capturing each adapter's outgoing fetch body and asserting on the token-limit key shape:

- OpenAI: body has \`max_completion_tokens\`, NOT \`max_tokens\`, value ≥ 1024.
- OpenAI-compatible: body has \`max_tokens\`, NOT \`max_completion_tokens\`.
- Anthropic: body has \`max_tokens\`, flat \`system\` field (not chat-role), single user message.
- Gemini: body has \`generationConfig.maxOutputTokens > 0\`, no top-level token key.

If a future refactor silently swaps these back, tests break immediately rather than in production on someone's next OpenAI model upgrade.

## Tests

- [x] \`pnpm --filter @defluff/core test\` — 57/57 pass (4 new)
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm --filter @defluff/extension build\` — clean

## Test plan (manual)

- [ ] Load unpacked extension, configure OpenAI provider with a reasoning model name (e.g., \`gpt-5\`, \`o1-preview\`, \`o3-mini\`), click De-Fluff — should succeed now
- [ ] Retry with \`gpt-4o-mini\` — should still succeed (max_completion_tokens works on older models too)
- [ ] Retry with Ollama pointing at a local model — should still succeed (max_tokens path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)