### PR TITLE
feat(providers): default to frontier models + document local-model setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "FinAegis Claude Code plugins. Currently ships Defluff — strip AI-generated fluff from emails.",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "defluff",
       "source": "./apps/claude-skill",
-      "description": "Reverse the AI in corporate email: detect AI / AI-assisted / human authorship, guess the prompt when AI was involved, classify urgency, extract 3–5 bullets of real intent. Mirrors the email's language. Detects invoice fraud / BEC, phishing, fake recruiters, and other scam red flags.",
-      "version": "0.2.0",
+      "description": "Reverse the AI in corporate email: detect AI / AI-assisted / human authorship, guess the prompt when AI was involved, classify urgency, extract 3–5 bullets of real intent. Mirrors the email's language. Names scam progressions (fake recruiter + calendly + wallet, invoice fraud / BEC, crypto / Web3 pitch) and refuses to launder a scam into legitimacy just because the reader replied politely.",
+      "version": "0.3.0",
       "homepage": "https://finaegis.github.io/defluff/",
       "repository": "https://github.com/FinAegis/defluff",
       "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -142,12 +142,30 @@ Then sideload `apps/outlook-addin/manifest.xml` from **Outlook Web → Get Add-i
 
 | Provider | Default model | How it connects |
 |---|---|---|
-| **Anthropic Claude** | `claude-haiku-4-5-20251001` | Messages API with the browser-direct header |
-| **OpenAI** | `gpt-4o-mini` | `dangerouslyAllowBrowser` — not actually dangerous here since it's your own key in your own browser |
-| **Google Gemini** | `gemini-2.5-flash` | Key as query param, native CORS |
-| **OpenAI-compatible** | `llama3` | Ollama (`http://localhost:11434/v1`), LM Studio, or any compatible endpoint |
+| **Anthropic Claude** | `claude-opus-4-7` | Messages API with the browser-direct header |
+| **OpenAI** | `gpt-5.4` | Chat Completions with `max_completion_tokens` — works on the reasoning models (o-series / GPT-5) and older chat models alike |
+| **Google Gemini** | `gemini-2.5-pro` | Key as query param, native CORS. (Preview tier `gemini-3.1-pro-preview` available via model override.) |
+| **OpenAI-compatible** | `llama3` | Ollama, LM Studio, LiteLLM, or any OpenAI-compatible endpoint. [Setup ↓](#running-against-a-local-model) |
 
 All four share one extraction prompt. Swap providers anytime from the options page.
+
+**A note on the defaults.** Defluff defaults to each provider's current frontier model rather than a mini/haiku/flash tier. Scam detection and AI-authorship classification are judgment tasks — smaller models regress meaningfully (they mark obvious AI-recruiter pitches as "legit" because they lean literal). A typical email is ~500-1500 input tokens + ~200 output, so per-click cost lands in the ~$0.01-0.05 range. If that's too much for your usage pattern, override the model to a cheaper tier (`claude-haiku-4-5`, `gpt-4o-mini`, `gemini-2.5-flash`) from the options page — the prompt still handles them, just with less aggression on edge cases.
+
+### Running against a local model
+
+Point Defluff at an Ollama or LM Studio instance and get zero per-call cost, full privacy, and no rate limits:
+
+1. **Install and run Ollama.** `brew install ollama` (or equivalent) then `ollama pull llama3` and `ollama serve`.
+2. **Allow the extension origin to call Ollama.** Ollama's default CORS config blocks browser requests. Start Ollama with:
+
+   ```bash
+   OLLAMA_ORIGINS='chrome-extension://*,moz-extension://*' ollama serve
+   ```
+
+   Or the more permissive `OLLAMA_ORIGINS='*'` if you're not fussy. On macOS with the Ollama app, `launchctl setenv OLLAMA_ORIGINS '*'` then restart the app.
+3. **Configure Defluff.** Options page → Provider: **OpenAI-compatible** → Base URL: `http://localhost:11434/v1` → Model: `llama3` (or whatever you pulled) → leave API key blank → Save.
+
+LM Studio is similar: start its local server, point the base URL at `http://localhost:1234/v1`. LiteLLM and other OpenAI-compatible gateways work the same way.
 
 ---
 

--- a/apps/claude-skill/.claude-plugin/plugin.json
+++ b/apps/claude-skill/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "defluff",
-  "description": "Reverse the AI in corporate email: detect AI / AI-assisted / human authorship, guess the prompt when AI was involved, classify urgency, extract 3–5 bullets of real intent. Mirrors the email's language. Detects invoice fraud / BEC, phishing, fake recruiters, and other scam red flags.",
+  "description": "Reverse the AI in corporate email: detect AI / AI-assisted / human authorship, guess the prompt when AI was involved, classify urgency, extract 3–5 bullets of real intent. Mirrors the email's language. Names scam progressions (fake recruiter + calendly + wallet, invoice fraud / BEC, crypto / Web3 pitch) and refuses to launder a scam into legitimacy just because the reader replied politely.",
   "author": {
     "name": "FinAegis"
   },

--- a/packages/core/src/providers/anthropic.ts
+++ b/packages/core/src/providers/anthropic.ts
@@ -1,7 +1,10 @@
 import { codeFromStatus, DefluffError } from '../errors.js';
 import type { AnthropicConfig, ProviderAdapter, ProviderRunArgs } from '../types.js';
 
-const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+// Default to the current flagship Opus. Scam detection is a judgment
+// task; smaller models (Haiku) regress meaningfully. Users can override
+// to a cheaper tier from the options page.
+const DEFAULT_MODEL = 'claude-opus-4-7';
 const API_URL = 'https://api.anthropic.com/v1/messages';
 const API_VERSION = '2023-06-01';
 

--- a/packages/core/src/providers/gemini.ts
+++ b/packages/core/src/providers/gemini.ts
@@ -1,7 +1,12 @@
 import { codeFromStatus, DefluffError } from '../errors.js';
 import type { GeminiConfig, ProviderAdapter, ProviderRunArgs } from '../types.js';
 
-const DEFAULT_MODEL = 'gemini-2.5-flash';
+// Default to Gemini 2.5 Pro (GA). We deliberately skip the
+// gemini-3.1-pro-preview default: preview SLA means unannounced
+// deprecations (see the 3.0 preview shutdown on 2026-03-09) and
+// occasional routing hiccups. Users who want to opt in to the
+// preview can set the model override from the options page.
+const DEFAULT_MODEL = 'gemini-2.5-pro';
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
 interface GeminiResponse {

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -16,10 +16,30 @@ export const PROVIDER_KINDS: readonly ProviderKind[] = [
  * in the model-override field. Update these in one place when a provider
  * ships a better default — do not duplicate in client apps.
  */
+/**
+ * Default model IDs. We default to each provider's current frontier
+ * model (Claude Opus 4.7, GPT-5.4, Gemini 2.5 Pro) rather than a cheap
+ * mini/haiku/flash tier. Scam detection and authorship classification
+ * are judgment tasks where smaller models regress meaningfully — see
+ * the AjunaVerse / fake-recruiter thread that a mini classified as
+ * "legit recruitment opportunity" until the prompt was tightened.
+ *
+ * Cost per click with these defaults is roughly 2–5× a mini tier
+ * (Anthropic Opus 4.7: $5 in / $25 out per 1M; GPT-5.4: $2.50 in /
+ * $15 out; Gemini 2.5 Pro: $1.25 in / $10 out at <=200K context).
+ * For a typical email (~500-1500 tokens in, ~200 tokens out) that
+ * works out to a few cents per click — still effectively free for
+ * personal use. Users who want to trade quality for cost can override
+ * the model from the options page.
+ */
 export const PROVIDER_DEFAULT_MODELS: Record<ProviderKind, string> = {
-  anthropic: 'claude-haiku-4-5-20251001',
-  openai: 'gpt-4o-mini',
-  gemini: 'gemini-2.5-flash',
+  anthropic: 'claude-opus-4-7',
+  openai: 'gpt-5.4',
+  // GA Pro, not the 3.1 preview — preview carries SLA risk and the
+  // user is paying per-token on their own key, so GA is the right
+  // default. Users can override to gemini-3.1-pro-preview or
+  // gemini-2.5-flash from the options page.
+  gemini: 'gemini-2.5-pro',
   'openai-compatible': 'llama3',
 };
 

--- a/packages/core/src/providers/openai.ts
+++ b/packages/core/src/providers/openai.ts
@@ -1,7 +1,13 @@
 import type { OpenAIConfig, ProviderAdapter } from '../types.js';
 import { callOpenAICompatible } from './openai-compatible.js';
 
-const DEFAULT_MODEL = 'gpt-4o-mini';
+// Default to the current frontier. Mini tiers (gpt-4o-mini, 3.5-turbo)
+// undercalled scams in real testing — they mark obvious AI-recruiter
+// pitches as "Legit thread / human / genuine recruitment opportunity"
+// because smaller models lean literal and skip skeptical pattern-
+// matching. GPT-5.4 handles judgment reliably. Users who want the
+// mini cost curve can override from the options page.
+const DEFAULT_MODEL = 'gpt-5.4';
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 
 /**


### PR DESCRIPTION
## Three asks in one PR

### (a) Plugin/skill sync

Claude plugin marketplace was still at **0.2.0** while OpenClaw had shipped **0.0.9** with the PR #35 prompt changes (crypto / Web3 pitch pattern, polite-reply-doesn't-launder rule, tightened authorship signals). The SKILL.md body is already byte-identical between the two; the only sync missing was the marketplace version bump so Claude Code installs reflect those changes.

- \`.claude-plugin/marketplace.json\`: \`0.2.0 → 0.3.0\`
- Both \`marketplace.json\` and \`apps/claude-skill/.claude-plugin/plugin.json\` descriptions updated to name the SCAM/progression detection explicitly.
- OpenClaw skill already at 0.0.9, no further bump needed (body unchanged since #35).

### (b) Yes, local models work. Here's how.

Added a **Running against a local model** section to the README covering:

- Installing Ollama, pulling a model, \`ollama serve\`.
- **The OLLAMA_ORIGINS CORS gotcha** — Ollama's default config blocks browser requests from the extension. Fix: \`OLLAMA_ORIGINS='chrome-extension://*,moz-extension://*' ollama serve\` (or \`'*'\` if you're not fussy). macOS app: \`launchctl setenv OLLAMA_ORIGINS '*'\` then restart.
- Configuring Defluff: Provider = **OpenAI-compatible**, Base URL = \`http://localhost:11434/v1\`, Model = \`llama3\` (or whatever), API key blank.
- LM Studio and LiteLLM work the same way.

Cross-linked from the providers table so users discover it without scrolling.

### (c) Frontier-model defaults

Current mini/haiku/flash defaults undercalled scams in real testing — the AjunaVerse thread came back as *"Legit thread / human / genuine recruitment opportunity"* on \`gpt-4o-mini\`. Switching defaults to each provider's current top tier:

| Provider | Before | After | Price (1M in / out) |
|---|---|---|---|
| Anthropic | \`claude-haiku-4-5-20251001\` | \`claude-opus-4-7\` | $5 / $25 |
| OpenAI | \`gpt-4o-mini\` | \`gpt-5.4\` | $2.50 / $15 |
| Gemini | \`gemini-2.5-flash\` | \`gemini-2.5-pro\` | $1.25 / $10 (≤200K ctx) |

**Deliberately skipped \`gemini-3.1-pro-preview\`.** Preview-tier SLA means unannounced deprecations (the 3.0 preview was shut off 2026-03-09). Users can opt in from the options page. Same escape hatch applies across the board: override the model from options if you want the cheap curve — the prompt still works on mini tiers, just with less aggression on edge cases.

**Cost impact:** a typical email (~500-1500 input tokens + ~200 output) lands at **~\$0.01-0.05 per click**, up from ~\$0.001 on mini. Documented explicitly in the README so nobody's surprised on their first bill. Still effectively free for personal use.

Comment blocks at each adapter's \`DEFAULT_MODEL\` and at \`PROVIDER_DEFAULT_MODELS\` explain the rationale and how to downgrade, so the "why Opus? why 5.4?" question has an answer that sits next to the code.

## Tests

- [x] \`pnpm --filter @defluff/core test\` — 57/57 pass (no regressions; adapters still respect the tokenLimitKey split)
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm --filter @defluff/extension build\` — clean

## Test plan (manual)

- [ ] Install fresh extension, pick Anthropic, leave model blank — should use \`claude-opus-4-7\`, scam detection should be crisp on the AjunaVerse shape
- [ ] Pick OpenAI, leave model blank — should use \`gpt-5.4\`, \`max_completion_tokens\` already shipped in #37
- [ ] Pick Gemini, leave model blank — should use \`gemini-2.5-pro\` (GA)
- [ ] Run through the local-model instructions: Ollama + llama3 + OLLAMA_ORIGINS set — confirm a click completes without CORS errors

## Version bumps

| Surface | Before | After |
|---|---|---|
| Claude plugin (marketplace.json + plugin.json) | 0.2.0 | 0.3.0 |
| OpenClaw skill | 0.0.9 (unchanged, published earlier) | 0.0.9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)