### PR TITLE
feat: tighten SCAM panel + "Waste their time" scam-bait generator

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,10 +1,18 @@
-import { DefluffError, summarize, summarizeThread, type ThreadMessage } from '@defluff/core';
 import {
+  DefluffError,
+  generateBait,
+  summarize,
+  summarizeThread,
+  type ThreadMessage,
+} from '@defluff/core';
+import {
+  MSG_GENERATE_BAIT,
   MSG_OPEN_OPTIONS,
   MSG_SUMMARIZE,
   MSG_SUMMARIZE_THREAD,
   MSG_TRIGGER_ACTIVE,
   type AppRequest,
+  type GenerateBaitResponse,
   type SummarizeResponse,
   type SummarizeThreadResponse,
 } from './shared/messages.js';
@@ -48,6 +56,11 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
 
   if (message.type === MSG_SUMMARIZE_THREAD) {
     void handleSummarizeThread(message.messages).then(sendResponse);
+    return true;
+  }
+
+  if (message.type === MSG_GENERATE_BAIT) {
+    void handleGenerateBait(message.messages).then(sendResponse);
     return true;
   }
 
@@ -95,6 +108,29 @@ async function handleSummarizeThread(
   try {
     const thread = await summarizeThread({ messages, provider });
     return { ok: true, thread };
+  } catch (err) {
+    if (err instanceof DefluffError) {
+      return { ok: false, error: err.message, code: err.code };
+    }
+    return { ok: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+async function handleGenerateBait(
+  messages: ThreadMessage[],
+): Promise<GenerateBaitResponse> {
+  const provider = await getProviderConfig();
+  if (!provider) {
+    return {
+      ok: false,
+      error: 'Open the Defluff options page and configure a provider first.',
+      code: 'unknown_provider',
+    };
+  }
+
+  try {
+    const text = await generateBait({ messages, provider });
+    return { ok: true, text };
   } catch (err) {
     if (err instanceof DefluffError) {
       return { ok: false, error: err.message, code: err.code };

--- a/apps/extension/src/content/ui/panel.ts
+++ b/apps/extension/src/content/ui/panel.ts
@@ -33,6 +33,14 @@ export interface PanelOptions {
   thread?: ThreadSummary;
   error?: PanelError;
   onDismiss?: () => void;
+  /**
+   * Callback wired by the content host when a SCAM thread was detected
+   * and the host can produce a bait reply on demand. When present and
+   * the thread verdict is SCAM, the panel renders a "Waste their time"
+   * button; clicking it calls this function and displays the returned
+   * draft in an editable textarea.
+   */
+  onGenerateBait?: () => Promise<string>;
 }
 
 const THREAD_VERDICT_LABELS: Record<ThreadVerdict, string> = {
@@ -74,7 +82,7 @@ export function createPanel(opts: PanelOptions): PanelController {
   if (isError && opts.error) {
     renderError(panel, opts.error);
   } else if (opts.thread) {
-    renderThread(panel, opts.thread);
+    renderThread(panel, opts.thread, opts.onGenerateBait);
   } else if (opts.summary) {
     renderSummary(panel, opts.summary);
   }
@@ -276,20 +284,29 @@ function buildVerdictRow(verdict: Verdict, reason?: string): HTMLElement {
 }
 
 /**
- * Render a thread-mode summary. The structure is:
+ * Render a thread-mode summary. Layout depends on the thread verdict:
  *
- *   [Thread-verdict strip]
- *   ── message 1 ──────────────
- *     [authored] [verdict] [bullets]
- *   ── message 2 ──────────────
- *     ...
- *   [Actions]
+ *   SCAM:
+ *     [Thread-verdict strip — red, pattern-named]
+ *     [Actions list]
+ *     [Waste their time button — generates a bait draft]
+ *     ▸ Per-message detail (collapsed)
  *
- * The thread verdict strip (LEGIT / MIXED / SCAM) is shown FIRST because
- * it's the headline answer — especially for SCAM, the reader should see
- * the pattern name before scrolling through per-message detail.
+ *   LEGIT (or unknown verdict):
+ *     [Thread-verdict strip]
+ *     [Per-message blocks — inline]
+ *     [Actions list]
+ *
+ * The SCAM layout exists because per-message detail on scam threads is
+ * mostly noise — the reader already knows "fake recruiter pitched me",
+ * the headline is the cross-message progression and what to do about
+ * it. Users who want the per-message breakdown click to expand.
  */
-function renderThread(panel: HTMLElement, thread: ThreadSummary): void {
+function renderThread(
+  panel: HTMLElement,
+  thread: ThreadSummary,
+  onGenerateBait?: () => Promise<string>,
+): void {
   const hasAnything =
     thread.messages.length > 0 || !!thread.threadVerdict || thread.actions.length > 0;
 
@@ -310,6 +327,25 @@ function renderThread(panel: HTMLElement, thread: ThreadSummary): void {
     );
   }
 
+  const isScam = thread.threadVerdict === 'scam';
+
+  if (isScam) {
+    // SCAM: Actions first (the concrete answer), then bait button,
+    // then per-message detail behind a disclosure.
+    if (thread.actions.length > 0) {
+      panel.appendChild(buildActionsBlock(thread.actions));
+    }
+    if (onGenerateBait) {
+      panel.appendChild(buildBaitBlock(onGenerateBait));
+    }
+    if (thread.messages.length > 0) {
+      panel.appendChild(buildCollapsedMessagesBlock(thread.messages));
+    }
+    return;
+  }
+
+  // LEGIT or unknown verdict: inline per-message blocks, actions at
+  // the bottom — the per-message detail IS the primary content here.
   for (let i = 0; i < thread.messages.length; i++) {
     const msg = thread.messages[i];
     if (!msg) continue;
@@ -319,6 +355,146 @@ function renderThread(panel: HTMLElement, thread: ThreadSummary): void {
   if (thread.actions.length > 0) {
     panel.appendChild(buildActionsBlock(thread.actions));
   }
+}
+
+function buildCollapsedMessagesBlock(
+  messages: ThreadSummary['messages'],
+): HTMLElement {
+  const disclosure = document.createElement('details');
+  disclosure.className = 'df-thread-detail-disclosure';
+  const summary = document.createElement('summary');
+  summary.textContent = `Per-message detail (${messages.length})`;
+  disclosure.appendChild(summary);
+  const wrapper = document.createElement('div');
+  wrapper.className = 'df-thread-detail-body';
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg) continue;
+    wrapper.appendChild(buildMessageBlock(msg, i === 0));
+  }
+  disclosure.appendChild(wrapper);
+  return disclosure;
+}
+
+function buildBaitBlock(
+  onGenerateBait: () => Promise<string>,
+): HTMLElement {
+  const block = document.createElement('section');
+  block.className = 'df-bait';
+
+  const label = document.createElement('p');
+  label.className = 'df-bait-label';
+  const icon = document.createElement('span');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '✉️';
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Your turn';
+  label.appendChild(icon);
+  label.appendChild(labelText);
+  block.appendChild(label);
+
+  const note = document.createElement('p');
+  note.className = 'df-bait-note';
+  note.textContent =
+    'Generate a time-wasting reply they can respond to by producing documentation they do not have. Your call whether to send it.';
+  block.appendChild(note);
+
+  const actions = document.createElement('div');
+  actions.className = 'df-bait-actions';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'df-cta';
+  button.textContent = 'Waste their time';
+  actions.appendChild(button);
+  block.appendChild(actions);
+
+  const resultWrap = document.createElement('div');
+  resultWrap.className = 'df-bait-result';
+  resultWrap.hidden = true;
+  block.appendChild(resultWrap);
+
+  button.addEventListener('click', () => {
+    void runBait(button, resultWrap, onGenerateBait);
+  });
+
+  return block;
+}
+
+async function runBait(
+  button: HTMLButtonElement,
+  result: HTMLElement,
+  onGenerateBait: () => Promise<string>,
+): Promise<void> {
+  button.disabled = true;
+  const originalLabel = button.textContent;
+  button.textContent = 'Writing…';
+  result.hidden = false;
+  result.replaceChildren();
+
+  try {
+    const text = await onGenerateBait();
+    renderBaitDraft(result, text);
+  } catch (err) {
+    renderBaitError(result, err);
+  } finally {
+    button.disabled = false;
+    button.textContent = originalLabel ?? 'Waste their time';
+  }
+}
+
+function renderBaitDraft(host: HTMLElement, draft: string): void {
+  host.replaceChildren();
+
+  const textarea = document.createElement('textarea');
+  textarea.className = 'df-bait-textarea';
+  textarea.value = draft;
+  textarea.rows = Math.min(14, Math.max(6, draft.split('\n').length + 1));
+  textarea.spellcheck = false;
+  host.appendChild(textarea);
+
+  const row = document.createElement('div');
+  row.className = 'df-bait-result-row';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'df-link';
+  copyBtn.textContent = 'Copy';
+  copyBtn.addEventListener('click', () => {
+    void copyToClipboard(textarea.value, copyBtn);
+  });
+  row.appendChild(copyBtn);
+
+  const disclaimer = document.createElement('span');
+  disclaimer.className = 'df-bait-disclaimer';
+  disclaimer.textContent =
+    'You are still talking to a scammer — do not paste anything real.';
+  row.appendChild(disclaimer);
+
+  host.appendChild(row);
+}
+
+async function copyToClipboard(text: string, button: HTMLButtonElement): Promise<void> {
+  const original = button.textContent;
+  try {
+    await navigator.clipboard.writeText(text);
+    button.textContent = 'Copied';
+  } catch {
+    button.textContent = 'Copy failed';
+  }
+  window.setTimeout(() => {
+    button.textContent = original ?? 'Copy';
+  }, 1500);
+}
+
+function renderBaitError(host: HTMLElement, err: unknown): void {
+  host.replaceChildren();
+  const msg = document.createElement('p');
+  msg.className = 'df-bait-error';
+  msg.textContent =
+    err instanceof Error && err.message
+      ? `Couldn't generate a reply: ${err.message}`
+      : "Couldn't generate a reply. Try again in a moment.";
+  host.appendChild(msg);
 }
 
 function buildThreadVerdictStrip(verdict: ThreadVerdict, reason?: string): HTMLElement {

--- a/apps/extension/src/content/ui/styles.ts
+++ b/apps/extension/src/content/ui/styles.ts
@@ -344,4 +344,85 @@ export const CONTENT_CSS = `
 /* Match the SCAM palette around the entire panel when the thread reads as
    a scam — the reader needs the hint that this is not just informational. */
 .df-panel[data-thread-verdict="scam"] { border-left-color: var(--df-error-accent); }
+
+/* Collapsible per-message detail. Only used on SCAM threads where the
+   Actions + thread-verdict strip is the headline and the per-message
+   breakdown is secondary. Disclosure keeps it one click away. */
+.df-thread-detail-disclosure {
+  margin: 12px 0 0;
+  font-size: 13px;
+}
+.df-thread-detail-disclosure summary {
+  cursor: pointer;
+  color: var(--df-muted);
+  user-select: none;
+  padding: 2px 0;
+  font-weight: 500;
+}
+.df-thread-detail-disclosure summary:hover { color: var(--df-fg); }
+.df-thread-detail-body {
+  margin-top: 8px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--df-panel-border);
+}
+
+/* "Waste their time" bait block — the anti-AI payoff. Visually distinct
+   from the rest of the panel with a tinted background and border so
+   the button reads as an offered action, not a repeat of the Actions
+   list above. */
+.df-bait {
+  margin: 12px 0 0;
+  padding: 12px 14px;
+  border: 1px solid var(--df-panel-border);
+  border-radius: 6px;
+  background: var(--df-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.df-bait-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--df-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.df-bait-note {
+  margin: 0;
+  font-size: 13px;
+  color: var(--df-muted);
+  line-height: 1.5;
+}
+.df-bait-actions { display: flex; gap: 10px; align-items: center; }
+.df-bait-result { margin: 4px 0 0; display: flex; flex-direction: column; gap: 8px; }
+.df-bait-textarea {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  padding: 10px 12px;
+  border: 1px solid var(--df-panel-border);
+  border-radius: 4px;
+  background: var(--df-panel-bg);
+  color: var(--df-fg);
+  resize: vertical;
+  min-height: 120px;
+  max-height: 320px;
+  outline: none;
+}
+.df-bait-textarea:focus { border-color: var(--df-accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--df-accent) 16%, transparent); }
+.df-bait-result-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--df-muted);
+}
+.df-bait-disclaimer { line-height: 1.45; flex: 1 1 200px; }
+.df-bait-error { margin: 0; color: var(--df-error-accent); font-size: 13px; }
 `;

--- a/apps/extension/src/content/ui/wireHost.ts
+++ b/apps/extension/src/content/ui/wireHost.ts
@@ -3,7 +3,9 @@ import type {
   SummarizeResponse,
   SummarizeThreadResponse,
 } from '../../shared/messages.js';
+import type { GenerateBaitResponse } from '../../shared/messages.js';
 import {
+  MSG_GENERATE_BAIT,
   MSG_OPEN_OPTIONS,
   MSG_SUMMARIZE,
   MSG_SUMMARIZE_THREAD,
@@ -276,6 +278,29 @@ function wireTarget(
       ? buildErrorPayload(activeResponse, dismiss)
       : undefined;
 
+    // Capture the raw thread so the panel's "Waste their time" button
+    // can reuse it to generate a bait draft later — the panel doesn't
+    // own the thread itself; it just calls back to the host.
+    const capturedThread = useThread ? (thread as ThreadMessage[]) : undefined;
+    const generateBait = capturedThread
+      ? async (): Promise<string> => {
+          let res: GenerateBaitResponse | undefined;
+          try {
+            res = await chrome.runtime.sendMessage({
+              type: MSG_GENERATE_BAIT,
+              messages: capturedThread,
+            });
+          } catch (err) {
+            throw err instanceof Error ? err : new Error('Extension error');
+          }
+          if (!res || typeof res !== 'object' || !('ok' in res)) {
+            throw new Error('No response from the extension. Try again.');
+          }
+          if (!res.ok) throw new Error(res.error);
+          return res.text;
+        }
+      : undefined;
+
     const panel = createPanel({
       ...(useThread && activeResponse.ok
         ? { thread: (activeResponse as { thread: ThreadSummary }).thread }
@@ -284,6 +309,7 @@ function wireTarget(
         ? { summary: (activeResponse as { summary: Summary }).summary }
         : {}),
       ...(errorPayload ? { error: errorPayload } : {}),
+      ...(generateBait ? { onGenerateBait: generateBait } : {}),
       onDismiss: dismiss,
     });
     decoratePanel?.(panel.element);

--- a/apps/extension/src/shared/messages.ts
+++ b/apps/extension/src/shared/messages.ts
@@ -2,6 +2,7 @@ import type { DefluffErrorCode, Summary, ThreadMessage, ThreadSummary } from '@d
 
 export const MSG_SUMMARIZE = 'summarize' as const;
 export const MSG_SUMMARIZE_THREAD = 'summarize_thread' as const;
+export const MSG_GENERATE_BAIT = 'generate_bait' as const;
 export const MSG_TRIGGER_ACTIVE = 'trigger_active' as const;
 export const MSG_OPEN_OPTIONS = 'open_options' as const;
 
@@ -12,6 +13,11 @@ export interface SummarizeRequest {
 
 export interface SummarizeThreadRequest {
   type: typeof MSG_SUMMARIZE_THREAD;
+  messages: ThreadMessage[];
+}
+
+export interface GenerateBaitRequest {
+  type: typeof MSG_GENERATE_BAIT;
   messages: ThreadMessage[];
 }
 
@@ -26,6 +32,7 @@ export interface OpenOptionsRequest {
 export type AppRequest =
   | SummarizeRequest
   | SummarizeThreadRequest
+  | GenerateBaitRequest
   | TriggerActiveRequest
   | OpenOptionsRequest;
 
@@ -35,4 +42,8 @@ export type SummarizeResponse =
 
 export type SummarizeThreadResponse =
   | { ok: true; thread: ThreadSummary }
+  | { ok: false; error: string; code?: DefluffErrorCode };
+
+export type GenerateBaitResponse =
+  | { ok: true; text: string }
   | { ok: false; error: string; code?: DefluffErrorCode };

--- a/packages/core/src/bait.test.ts
+++ b/packages/core/src/bait.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefluffError } from './errors.js';
+import { buildBaitUserPrompt, BAIT_SYSTEM_PROMPT } from './prompt.js';
+import { generateBait } from './summarize.js';
+
+function mockFetchOnce(status: number, payload: unknown): void {
+  const response = new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
+}
+
+describe('BAIT_SYSTEM_PROMPT', () => {
+  it('contains the load-bearing constraints', () => {
+    // These constraints are what keep the feature from being a liability:
+    // no fake credentials the scammer could weaponize, no phishing,
+    // never reveal it's bait. If any of these drift out of the prompt
+    // in future edits the whole thing becomes a safety risk.
+    expect(BAIT_SYSTEM_PROMPT).toMatch(/never\s+fabricate/i);
+    expect(BAIT_SYSTEM_PROMPT).toMatch(/never\s+reveal/i);
+    expect(BAIT_SYSTEM_PROMPT).toMatch(/never\s+generate\s+phishing/i);
+    expect(BAIT_SYSTEM_PROMPT).toMatch(/mirror.+language/i);
+  });
+});
+
+describe('buildBaitUserPrompt', () => {
+  it('numbers messages and wraps the thread for the model', () => {
+    const prompt = buildBaitUserPrompt([
+      { sender: 'Laycee', body: 'Join our Web3 project as CTO!' },
+      { sender: 'Marijus', body: 'Interested in hearing more' },
+    ]);
+    expect(prompt).toContain('<scam-thread>');
+    expect(prompt).toContain('[1] Laycee');
+    expect(prompt).toContain('[2] Marijus');
+    expect(prompt).toContain('Return only the reply text');
+  });
+});
+
+describe('generateBait', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the trimmed reply text end-to-end through the OpenAI shape', async () => {
+    const draft =
+      'Thanks for the intro. Before booking anything, I\'d need audited ' +
+      'financials for the last four quarters, the full cap table with ' +
+      'founder vesting, the token economics whitepaper, and an independent ' +
+      'smart-contract audit from Trail of Bits or Quantstamp. Once those ' +
+      'are in hand I can find 15 minutes. What\'s the fastest way to send them over?';
+
+    mockFetchOnce(200, {
+      choices: [{ message: { content: `  ${draft}  \n` } }],
+    });
+
+    const text = await generateBait({
+      messages: [
+        { sender: 'Laycee', body: 'Exciting opportunity at ajuna.io...' },
+        { sender: 'Marijus', body: 'Interested' },
+        { sender: 'Laycee', body: 'Book a call: calendly.com/...' },
+      ],
+      provider: { kind: 'openai', apiKey: 'sk-test' },
+    });
+
+    expect(text).toBe(draft);
+  });
+
+  it('rejects an empty message list', async () => {
+    await expect(
+      generateBait({ messages: [], provider: { kind: 'openai', apiKey: 'sk-test' } }),
+    ).rejects.toMatchObject({ code: 'bad_request' });
+  });
+
+  it('rejects a thread with only whitespace bodies', async () => {
+    await expect(
+      generateBait({
+        messages: [{ body: '   ' }],
+        provider: { kind: 'openai', apiKey: 'sk-test' },
+      }),
+    ).rejects.toBeInstanceOf(DefluffError);
+  });
+
+  it('throws when the provider returns empty text', async () => {
+    mockFetchOnce(200, {
+      choices: [{ message: { content: '   ' } }],
+    });
+
+    await expect(
+      generateBait({
+        messages: [{ sender: 'A', body: 'pitch' }],
+        provider: { kind: 'openai', apiKey: 'sk-test' },
+      }),
+    ).rejects.toMatchObject({ code: 'server' });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export { DefluffError } from './errors.js';
 export type { DefluffErrorCode } from './errors.js';
 export { parseBullets, parseSummary, parseThreadSummary } from './parse.js';
 export {
+  BAIT_SYSTEM_PROMPT,
+  buildBaitUserPrompt,
   buildThreadUserPrompt,
   buildUserPrompt,
   SYSTEM_PROMPT,
@@ -19,7 +21,7 @@ export {
   PROVIDER_KINDS,
   PROVIDER_LABELS,
 } from './providers/index.js';
-export { summarize, summarizeThread } from './summarize.js';
+export { generateBait, summarize, summarizeThread } from './summarize.js';
 export { toUserError } from './user-errors.js';
 export type { UserError, UserErrorAction } from './user-errors.js';
 export {
@@ -43,6 +45,7 @@ export type {
   ProviderKind,
   ProviderRunArgs,
   Summary,
+  GenerateBaitOptions,
   SummarizeOptions,
   SummarizeThreadOptions,
   ThreadAction,

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -262,6 +262,71 @@ export const THREAD_SYSTEM_PROMPT = [
 ].join('\n');
 
 /**
+ * Scam-bait generator. Used only when the thread has been classified
+ * SCAM and the reader wants to waste the scammer's time rather than
+ * disengage silently. Generates a single reply that demands extensive
+ * due-diligence documentation before agreeing to the Calendly / call /
+ * wallet-connect push — forces the scammer to either produce documents
+ * they don't have (they won't) or go dark.
+ *
+ * Hard guardrails (load-bearing, do not soften):
+ * - Never fabricates the reader's real credentials, company, wallet,
+ *   or identity. Anything the scammer could weaponize stays vague.
+ * - Never includes real private information about anyone.
+ * - Never reveals that this is bait — the reply reads as a cautious
+ *   serious-professional persona.
+ * - Mirrors the scammer's language. French pitch → French bait.
+ */
+export const BAIT_SYSTEM_PROMPT = [
+  'You are drafting a reply to a CONFIRMED scam message. The reader has',
+  'already identified this thread as a scam and wants a time-wasting',
+  'reply — they do not want to engage, they want the scammer to burn',
+  'effort producing documentation that will never be read.',
+  '',
+  'Write a single reply (3-6 sentences, optionally a short bulleted',
+  'list of documentation requests) that:',
+  '',
+  '- Stays in character as a serious, busy professional who is',
+  '  tentatively interested but requires extensive documentation',
+  '  before engaging further.',
+  '- Requests 4-7 concrete, plausible-sounding documents or pieces of',
+  '  information that a legitimate counterparty would have ready.',
+  '  Tailor the asks to the specific scam context — for a Web3',
+  '  recruiter scam, ask for audited financials, cap table with',
+  '  founder vesting, token economics whitepaper with insider',
+  '  schedule, smart-contract audit from a reputable firm, full',
+  '  team backgrounds, and a competitive analysis. For invoice',
+  '  fraud, ask for purchase order reference, original signed',
+  '  contract, bank verification via a known channel.',
+  '- Refuses the external-call push (Calendly / Telegram / WhatsApp).',
+  '  Makes the call conditional on receiving the documentation first.',
+  '',
+  'Hard constraints (do not violate):',
+  '- NEVER reveal that this is bait. The scammer should think the',
+  '  reader is a cautious mark still worth selling to.',
+  '- NEVER fabricate the reader\'s credentials, company name, job',
+  '  title, net worth, wallet address, or any other identity detail',
+  '  the scammer could use against them. Keep the reader\'s persona',
+  '  deliberately vague ("my team", "our compliance process", "our',
+  '  investment committee").',
+  '- NEVER include real private information about any real person.',
+  '- NEVER use threatening, abusive, or sexually explicit language.',
+  '- NEVER promise money, access, or credentials.',
+  '- NEVER generate phishing links, malware instructions, or',
+  '  anything that could harm the scammer\'s infrastructure — we',
+  '  are wasting time, not retaliating.',
+  '',
+  'Language:',
+  '- Mirror the primary language the scammer used in the thread.',
+  '  French pitch → French reply. German → German. Match their',
+  '  register (formal / informal) too.',
+  '',
+  'Output ONLY the reply text. No preamble ("Here is your reply:"),',
+  'no explanatory notes, no sign-off advice, no quote-wrapping. Start',
+  'with the greeting the reader would send and end with a sign-off.',
+].join('\n');
+
+/**
  * Serialize a list of ThreadMessage into a user-prompt payload. Each message
  * is numbered for deterministic counting; unknown sender/timestamp fall back
  * to "unknown" rather than being omitted, so the block header shape stays
@@ -279,4 +344,25 @@ export function buildThreadUserPrompt(
     ].join('\n');
   });
   return `<thread>\n${blocks.join('\n\n---\n\n')}\n</thread>`;
+}
+
+/**
+ * Build the user prompt for the scam-bait generator. The scammer's
+ * thread is passed verbatim so the model can calibrate the bait to
+ * the specific scam shape (recruiter, BEC, crypto pitch, etc.).
+ */
+export function buildBaitUserPrompt(
+  messages: readonly { sender?: string; body: string }[],
+): string {
+  const blocks = messages.map((msg, index) => {
+    const sender = (msg.sender ?? 'unknown').trim() || 'unknown';
+    return `[${index + 1}] ${sender}:\n${msg.body.trim()}`;
+  });
+  return [
+    '<scam-thread>',
+    blocks.join('\n\n---\n\n'),
+    '</scam-thread>',
+    '',
+    'Draft the time-wasting reply now. Return only the reply text.',
+  ].join('\n');
 }

--- a/packages/core/src/summarize.ts
+++ b/packages/core/src/summarize.ts
@@ -1,6 +1,8 @@
 import { DefluffError } from './errors.js';
 import { parseSummary, parseThreadSummary } from './parse.js';
 import {
+  BAIT_SYSTEM_PROMPT,
+  buildBaitUserPrompt,
   buildThreadUserPrompt,
   buildUserPrompt,
   SYSTEM_PROMPT,
@@ -13,6 +15,7 @@ import {
   openaiCompatibleAdapter,
 } from './providers/index.js';
 import type {
+  GenerateBaitOptions,
   ProviderConfig,
   ProviderRunArgs,
   Summary,
@@ -80,6 +83,40 @@ export async function summarizeThread(
     );
   }
   return thread;
+}
+
+/**
+ * Generate a time-wasting bait reply to a confirmed scam thread. The
+ * caller is expected to only invoke this when the thread has been
+ * classified SCAM — there is no verdict check here; the button that
+ * triggers this is only shown in that case.
+ *
+ * Returns the raw reply text, trimmed. The panel renders it into an
+ * editable textarea so the reader can tweak before copying.
+ */
+export async function generateBait(opts: GenerateBaitOptions): Promise<string> {
+  const { messages, provider, signal } = opts;
+  if (messages.length === 0) {
+    throw new DefluffError('bad_request', 'No thread to bait.');
+  }
+  if (!messages.some((m) => m.body.trim().length > 0)) {
+    throw new DefluffError('bad_request', 'Thread has no non-empty messages.');
+  }
+
+  const args: ProviderRunArgs = {
+    systemPrompt: BAIT_SYSTEM_PROMPT,
+    userPrompt: buildBaitUserPrompt(messages),
+    ...(signal ? { signal } : {}),
+  };
+
+  const raw = await dispatchProvider(provider, args);
+  const text = raw.trim();
+  if (!text) {
+    throw new DefluffError('server', 'Provider returned no bait text.', {
+      detail: raw,
+    });
+  }
+  return text;
 }
 
 function dispatchProvider(provider: ProviderConfig, args: ProviderRunArgs): Promise<string> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,6 +129,18 @@ export interface SummarizeThreadOptions {
   signal?: AbortSignal;
 }
 
+/**
+ * Options for the scam-bait generator. Only used when the thread has
+ * been classified SCAM — the generated reply is a deliberately
+ * time-wasting draft the reader can send back to the scammer to burn
+ * their effort producing documentation that will never be read.
+ */
+export interface GenerateBaitOptions {
+  messages: ThreadMessage[];
+  provider: ProviderConfig;
+  signal?: AbortSignal;
+}
+
 export interface ProviderRunArgs {
   systemPrompt: string;
   userPrompt: string;


### PR DESCRIPTION
## Two changes, one theme: what happens on a SCAM thread

### 1. Tighten — SCAM panel layout

The previous layout buried the actionable answer under per-message detail. For SCAM threads, the priority flips:

\`\`\`
[Thread-verdict strip]        pattern-named, red — unchanged
[Actions list]                the concrete \"what to do\"
[Waste their time block]      new bait button
▸ Per-message detail          collapsed, one click to expand
\`\`\`

LEGIT threads keep the old inline layout because there the per-message detail IS the primary content. The split means a confirmed scam reads as one glanceable decision + hidden receipts, while a legit thread still shows the full breakdown.

### 2. \"Waste their time\" — scam-bait generator

You asked for it, I agree: if AI is being used to scam you, use AI to burn the scammer's time. When the thread is SCAM, a new button generates a deliberately time-wasting reply — a polite cautious-professional persona asking for 4–7 concrete due-diligence documents before agreeing to the Calendly / wallet-connect push. The scammer either produces documentation they don't have (they won't) or goes dark.

**What the generated reply looks like for the AjunaVerse case** (model-dependent, rough shape):

> Thanks for the intro, Laycee. Before we schedule anything, I'll need the audited financials for the last four quarters, the full cap table with founder vesting, the token economics whitepaper with insider schedule, an independent smart-contract audit from Trail of Bits or Quantstamp, full team LinkedIn / GitHub backgrounds, and a competitive analysis vs Polymarket and Kalshi. Once my team has reviewed those I can find 15 minutes. What's the fastest way to send the documentation over?

Polite. Plausible. Unfakeable. Total time-waster.

**Hard guardrails in \`BAIT_SYSTEM_PROMPT\`** (tested explicitly — \`bait.test.ts\` asserts these stay in the prompt to guard against someone softening the safety rail):
- NEVER reveal it's bait
- NEVER fabricate the reader's credentials, company, wallet, or identity — anything the scammer could weaponize
- NEVER include real private info about any real person
- NEVER generate phishing links, malware, or retaliation content
- Mirrors the scammer's language (French pitch → French bait)

**UX:**
- Button appears only on SCAM threads.
- Clicking shows 'Writing…' state, generates via the user's configured provider (same key, same cost curve as summarize).
- Result renders as an **editable textarea** + a \`Copy\` button + disclaimer: *\"You are still talking to a scammer — do not paste anything real.\"*
- Errors render in the same block.

## What changed

\`packages/core\`
- \`BAIT_SYSTEM_PROMPT\`, \`buildBaitUserPrompt\`, \`generateBait\`, \`GenerateBaitOptions\` type.
- Full index exports.
- 6 new tests in \`bait.test.ts\` — prompt constraints, user-prompt wrapping, end-to-end through OpenAI shape, three input-validation paths.

\`apps/extension\`
- \`MSG_GENERATE_BAIT\` + \`GenerateBaitResponse\` in \`shared/messages.ts\`.
- \`background.ts\` dispatches thread messages to \`generateBait\`.
- \`panel.ts\` gets \`onGenerateBait\` callback wiring + \`buildBaitBlock\` + \`runBait\`. SCAM-thread layout reworks as described.
- \`wireHost.ts\` captures the raw \`ThreadMessage[]\` in a closure and passes the bait callback to the panel. Panel stays decoupled from \`chrome.runtime\` directly.
- \`styles.ts\` adds \`.df-bait*\` rules + collapsible \`.df-thread-detail-disclosure\`.

## Tests

- [x] \`pnpm --filter @defluff/core test\` — 63/63 (6 new)
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm --filter @defluff/extension build\` — clean

## Test plan (manual)

- [ ] Load unpacked extension; open the AjunaVerse thread; click De-Fluff — confirm:
  - [ ] Thread-verdict strip shows SCAM
  - [ ] Actions list renders immediately under the strip
  - [ ] \"Waste their time\" button is present
  - [ ] Per-message detail is collapsed behind a disclosure
- [ ] Click \"Waste their time\" — confirm 'Writing…' state, then textarea with a plausible time-wasting draft
- [ ] Edit the draft, click Copy — confirm clipboard contains the edited text
- [ ] Click again — confirm regeneration works
- [ ] Test on a LEGIT thread — confirm old inline layout is preserved and no bait button
- [ ] Test on a French-language scam thread — confirm bait draft is in French

## Not changed

- Skill files — the bait feature is extension-only by design; running bait in Claude Code / OpenClaw works the same way via the \`SKILL.md\` thread instructions (the skill can already generate follow-up text when asked), so no skill sync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)