### PR TITLE
release: v0.1.1 — ship Outlook cloud.microsoft + Gmail dedup fixes to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Prose collapses into bullets.
 <tr>
 <td>
 
+**[Chrome Web Store](https://chromewebstore.google.com/detail/defluff/focbcpblgbbebppigdalpajdgmkmejfo)** — browser extension for Gmail / Outlook Web / LinkedIn Messaging
+
+</td>
+<td>
+
+[**Add to Chrome →**](https://chromewebstore.google.com/detail/defluff/focbcpblgbbebppigdalpajdgmkmejfo)
+
+</td>
+</tr>
+<tr>
+<td>
+
 **[Claude Code plugin](apps/claude-skill#readme)** — Anthropic agent surface
 
 </td>
@@ -112,7 +124,6 @@ openclaw skills install defluff
 
 ### Coming soon (pending live-testing — track in [#7](https://github.com/FinAegis/defluff/issues/7))
 
-- Chrome Web Store — browser extension for Gmail / Outlook Web / LinkedIn Messaging
 - Edge Add-ons — same build
 - Firefox AMO — same build
 - Microsoft AppSource — Outlook add-in (desktop + web)

--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -51,7 +51,7 @@ type Manifest = ManifestV3Export & {
 export default defineManifest({
   manifest_version: 3,
   name: 'Defluff',
-  version: '0.1.0',
+  version: '0.1.1',
   description: 'Strip AI-generated padding from emails. Your keys, your models, no servers.',
   // Firefox/AMO requires a stable per-extension id declared in the manifest
   // (Chrome derives its id from the crx signature). Using an email-shaped id

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defluff/extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Defluff browser extension for Gmail and Outlook Web.",
   "type": "module",
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "package": "node ../../scripts/package-extension.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },

--- a/apps/outlook-addin/public/index.html
+++ b/apps/outlook-addin/public/index.html
@@ -566,11 +566,8 @@
         One-click extension for Gmail, Outlook, and LinkedIn. Detects whether a message was written by AI, polished by AI, or by a human — then extracts 3–5 bullets of what the sender actually wants, in the email's own language. Zero servers. Your keys, your models, your data.
       </p>
       <div class="ctas">
-        <span class="btn primary" aria-disabled="true" role="link" aria-label="Add to Chrome — pending Chrome Web Store review">
-          Add to Chrome <span class="tag">Pending review</span>
-        </span>
-        <a class="btn primary" href="https://github.com/FinAegis/defluff/tree/main/apps/extension#development">
-          Install from source <span class="tag">v0.1</span>
+        <a class="btn primary" href="https://chromewebstore.google.com/detail/defluff/focbcpblgbbebppigdalpajdgmkmejfo">
+          Add to Chrome <span class="tag">v0.1.1</span>
         </a>
         <a class="btn secondary" href="https://github.com/FinAegis/defluff/tree/main/apps/claude-skill#readme">
           Claude Code plugin <span class="tag">Claude</span>
@@ -592,9 +589,9 @@
           Buy us a coffee
         </a>
       </div>
-      <p class="note">Chrome Web Store submission is in review — until it's approved, install from source with the steps below. Firefox and Edge mirrors follow Chrome approval.</p>
+      <p class="note">Live on the Chrome Web Store. Edge, Firefox and Microsoft AppSource mirrors coming next.</p>
       <details class="install-source">
-        <summary>Install from source (until Chrome Web Store approval)</summary>
+        <summary>Prefer to install from source?</summary>
         <ol>
           <li>Clone: <code>git clone https://github.com/FinAegis/defluff.git &amp;&amp; cd defluff</code></li>
           <li>Build: <code>pnpm install &amp;&amp; pnpm --filter @defluff/extension build</code></li>

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -130,7 +130,7 @@ Lead with "your organization's CISO already banned Grammarly and Otter." Skip th
 - [ ] 20-second demo video (no voiceover; one click, reversed prompt + verdict + bullets, done)
 - [ ] 2–3 variant screenshots: one **ACTIONABLE** (work email with deadline), one **RESPONSE-NEEDED** (colleague asking a question), one **NOISE** (✓ sales pitch, `docs/screenshot.jpg`). Chrome Web Store wants 3–5 promo shots at 1280×800.
 - [ ] Landing page live
-- [ ] Chrome Web Store listing approved
+- [x] Chrome Web Store listing approved — https://chromewebstore.google.com/detail/defluff/focbcpblgbbebppigdalpajdgmkmejfo
 - [ ] Edge Add-ons listing approved
 - [ ] Firefox AMO submission in queue
 - [ ] AppSource submission in queue

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "icons": "node scripts/generate-icons.mjs",
-    "skill:publish": "node scripts/publish-skill.mjs"
+    "skill:publish": "node scripts/publish-skill.mjs",
+    "package:chrome": "pnpm --filter @defluff/extension package"
   },
   "devDependencies": {
     "sharp": "^0.34.5"

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Build + zip the extension into a Chrome-Web-Store-ready artifact.
+//
+// Output: apps/defluff-v<version>-chrome.zip, with dist/ contents at the
+// archive root (the store rejects nested-folder zips).
+//
+// The same zip is accepted by Edge Add-ons and Firefox AMO — our manifest
+// declares browser_specific_settings.gecko so AMO will take it as-is.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import { readFile, rm, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const extensionDir = resolve(repoRoot, 'apps/extension');
+const distDir = resolve(extensionDir, 'dist');
+const appsDir = resolve(repoRoot, 'apps');
+
+const pkg = JSON.parse(await readFile(resolve(extensionDir, 'package.json'), 'utf8'));
+const version = pkg.version;
+const zipPath = resolve(appsDir, `defluff-v${version}-chrome.zip`);
+
+console.log(`→ Building @defluff/extension@${version}`);
+run('pnpm', ['--filter', '@defluff/extension', 'build'], { cwd: repoRoot });
+
+// Verify the manifest ended up with the version we expect — cheap guard
+// against a stale manifest.config.ts that doesn't match package.json.
+const manifestPath = resolve(distDir, 'manifest.json');
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+if (manifest.version !== version) {
+  throw new Error(
+    `Version mismatch: package.json is ${version} but built manifest is ${manifest.version}. ` +
+      `Update apps/extension/manifest.config.ts to match package.json.`,
+  );
+}
+
+// Overwrite any previous zip at this version so the script is idempotent.
+await rm(zipPath, { force: true });
+
+console.log(`→ Zipping ${distDir} → ${zipPath}`);
+// Zip the *contents* of dist/, not the dist folder itself. Chrome rejects
+// archives that nest everything under a single top-level directory.
+execFileSync('zip', ['-r', '-q', zipPath, '.'], { cwd: distDir });
+
+const { size } = await stat(zipPath);
+console.log(`✓ ${zipPath} (${(size / 1024).toFixed(1)} KB)`);
+console.log('\nUpload at https://chrome.google.com/webstore/devconsole');
+console.log('  → Defluff → Package → Upload new package');
+
+function run(cmd, args, opts) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (result.status !== 0) {
+    throw new Error(`${cmd} ${args.join(' ')} exited with ${result.status}`);
+  }
+}


### PR DESCRIPTION
## Summary

Cuts v0.1.1 so the fixes that landed in 818dd48 can go out to the Chrome Web Store (the live v0.1.0 listing still has the old Outlook selector and the Gmail double-button bug).

- Bumps `@defluff/extension` to 0.1.1 (manifest + package.json).
- Adds `pnpm package:chrome` — builds, version-checks the emitted manifest, and zips `dist/` contents (flat, not nested) into `apps/defluff-v<version>-chrome.zip`. The same zip is accepted by Edge Add-ons and Firefox AMO.
- Landing page: canonicalized Chrome Web Store URL with the `/defluff/` slug, replaced the "review in progress" disclaimer with a live-on-store line, bumped the version tag, and promoted Chrome Web Store into the README "Available now" table.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r test` — 34/34 pass
- [x] `pnpm package:chrome` — emits `apps/defluff-v0.1.1-chrome.zip` (344 KB, 27 files, flat layout)
- [x] Built manifest version matches `0.1.1`; `outlook.cloud.microsoft` present in host_permissions, content_scripts, and the web-accessible manifest
- [ ] Manual: upload the zip at chrome.google.com/webstore/devconsole → wait for review
- [ ] Manual: landing page deploys from GH Pages and the Chrome CTA resolves to the public store listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)