### PR TITLE
fix(extension): Firefox-compatible background.scripts fallback (v0.1.2)

### DIFF
--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -51,7 +51,7 @@ type Manifest = ManifestV3Export & {
 export default defineManifest({
   manifest_version: 3,
   name: 'Defluff',
-  version: '0.1.1',
+  version: '0.1.2',
   description: 'Strip AI-generated padding from emails. Your keys, your models, no servers.',
   // Firefox/AMO requires a stable per-extension id declared in the manifest
   // (Chrome derives its id from the crx signature). Using an email-shaped id
@@ -69,6 +69,11 @@ export default defineManifest({
     default_icon: ICONS,
   },
   options_ui: { page: 'src/options/index.html', open_in_tab: true },
+  // Firefox needs `background.scripts` as a fallback for `service_worker`,
+  // but @crxjs/vite-plugin strips any `scripts` key we declare here (it only
+  // emits Chrome's `service_worker`). The Firefox-compatible fallback is
+  // injected into dist/manifest.json at package time —
+  // see scripts/package-extension.mjs.
   background: { service_worker: 'src/background.ts', type: 'module' },
   commands: {
     defluff_active: {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defluff/extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Defluff browser extension for Gmail and Outlook Web.",
   "type": "module",

--- a/apps/outlook-addin/public/index.html
+++ b/apps/outlook-addin/public/index.html
@@ -567,7 +567,7 @@
       </p>
       <div class="ctas">
         <a class="btn primary" href="https://chromewebstore.google.com/detail/defluff/focbcpblgbbebppigdalpajdgmkmejfo">
-          Add to Chrome <span class="tag">v0.1.1</span>
+          Add to Chrome <span class="tag">v0.1.2</span>
         </a>
         <a class="btn secondary" href="https://github.com/FinAegis/defluff/tree/main/apps/claude-skill#readme">
           Claude Code plugin <span class="tag">Claude</span>

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -9,7 +9,7 @@
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createReadStream } from 'node:fs';
-import { readFile, rm, stat } from 'node:fs/promises';
+import { readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -35,6 +35,20 @@ if (manifest.version !== version) {
     `Version mismatch: package.json is ${version} but built manifest is ${manifest.version}. ` +
       `Update apps/extension/manifest.config.ts to match package.json.`,
   );
+}
+
+// Inject the Firefox-compatible `background.scripts` fallback. @crxjs/vite-
+// plugin strips any `scripts` key we declare in manifest.config.ts (it only
+// emits the Chrome-style `service_worker`). Without this fallback, AMO's
+// linter rejects the upload with:
+//   "Unsupported /background/service_worker manifest property used without
+//    /background/scripts ... as Firefox-compatible fallback."
+// Chrome ignores `scripts` when `service_worker` is present; Firefox reads
+// `scripts` as an event-page entry. `type: "module"` applies to both.
+if (manifest.background?.service_worker && !manifest.background.scripts) {
+  manifest.background.scripts = [manifest.background.service_worker];
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  console.log('→ Patched dist/manifest.json: added background.scripts fallback for Firefox');
 }
 
 // Overwrite any previous zip at this version so the script is idempotent.


### PR DESCRIPTION
## Summary

AMO's linter rejects the v0.1.1 zip with:

> Unsupported /background/service_worker manifest property used without /background/scripts ... as Firefox-compatible fallback.

Chrome's MV3 uses `background.service_worker`; Firefox's MV3 wants `background.scripts` alongside it as a fallback. @crxjs/vite-plugin only emits `service_worker` — anything we declare in manifest.config.ts gets stripped. So the fallback is injected post-build in scripts/package-extension.mjs before zipping.

Chrome ignores `scripts` when `service_worker` is present; Firefox reads it as an event-page entry. `type: "module"` applies to both, and the generated `service-worker-loader.js` is an ES-module re-export that Firefox can load as-is.

Bumped 0.1.1 → 0.1.2 so Chrome/Edge/Firefox submissions all ship the same bits. v0.1.1 went to Chrome earlier today but hasn't cleared review — re-uploading replaces the in-review submission.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r test` — 63/63 pass
- [x] `pnpm package:chrome` emits `apps/defluff-v0.1.2-chrome.zip`
- [x] Zipped `manifest.json` has both `background.service_worker` and `background.scripts`, both pointing at `service-worker-loader.js`
- [ ] Manual: re-upload to Chrome Web Store (replaces v0.1.1 in review)
- [ ] Manual: upload same zip to Firefox AMO — validator should pass now
- [ ] Manual: upload same zip to Edge Add-ons

🤖 Generated with [Claude Code](https://claude.com/claude-code)