### PR TITLE
fix(extension): declare data_collection_permissions for AMO submission

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -56,6 +56,23 @@ because none exists.
   The provider's servers may retain your data according to that provider's
   own retention policy — see below.
 
+## Data-category disclosure (Firefox AMO transparency)
+
+Starting in 2025, Mozilla requires every Firefox extension to list the
+user-data categories it handles so the install dialog can show them
+upfront. Defluff declares one category:
+
+- **personalCommunications** — the body of the email (or LinkedIn message)
+  you explicitly click *De-Fluff* on. It is sent directly from your
+  browser to the LLM provider you configured. No copy transits any
+  Defluff-operated server, because none exists; zero retention on our
+  side is a property of the architecture, not of a policy promise.
+
+We deliberately do **not** declare `authenticationInfo` for your LLM API
+key: you enter it yourself, it stays in `chrome.storage.sync` on your
+machine, and it's sent only to the provider you chose, as that provider's
+own auth header — we never collect or transmit it anywhere else.
+
 ## Third parties: your chosen LLM provider
 
 When you click De-Fluff, the message body is sent to the provider you

--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -46,6 +46,14 @@ type Manifest = ManifestV3Export & {
   browser_specific_settings?: {
     gecko?: { id: string; strict_min_version?: string };
   };
+  // Firefox AMO (2025+ submissions) requires an explicit declaration of
+  // which user-data categories the extension handles. Reviewed at upload
+  // time; missing field rejects the submission.
+  browser_specific_settings_gecko_only?: never;
+  data_collection_permissions?: {
+    required?: readonly string[];
+    optional?: readonly string[];
+  };
 };
 
 export default defineManifest({
@@ -64,6 +72,20 @@ export default defineManifest({
     },
   },
   icons: ICONS,
+  // Firefox/AMO transparency requirement (2025+). We declare the category
+  // the extension routes to third parties so users see it in the install
+  // dialog. `personalCommunications` = the email body the user asks us to
+  // summarize; it's sent directly from their browser to the LLM provider
+  // they configured (Anthropic / OpenAI / Gemini / self-hosted Ollama).
+  // Zero retention beyond that is a function of architecture, not of this
+  // declaration — we never see the data on any server we operate.
+  // The user's API key is stored locally in chrome.storage.sync and passed
+  // through to their chosen provider as auth; not declared here because
+  // the user supplies it rather than us collecting it.
+  // Chrome ignores this top-level field; Firefox reads it.
+  data_collection_permissions: {
+    required: ['personalCommunications'],
+  },
   action: {
     default_title: 'Defluff',
     default_icon: ICONS,


### PR DESCRIPTION
## Summary

Next AMO error after #42:

> The \"data_collection_permissions\" property is missing.

Mozilla added this transparency requirement in 2025 — every Firefox extension must list which user-data categories it handles so the install dialog can surface that to users upfront.

Declared `required: ["personalCommunications"]` — the email body the user explicitly clicks *De-Fluff* on is routed from their browser directly to the LLM provider they configured. Deliberately **not** declaring `authenticationInfo` for the API key: the user supplies it, it lives in `chrome.storage.sync` on their machine, and it's only passed through as provider auth — we don't collect it.

Chrome and Edge ignore the top-level field, so the same zip serves all three stores. @crxjs/vite-plugin passes the field through unchanged (unlike `background.scripts` in #42, which needed the post-build patch).

Also added a "Data-category disclosure" section to PRIVACY.md so AMO reviewers and a privacy-curious user land on the same explanation.

No version bump — v0.1.2 still stands.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm package:chrome` emits `apps/defluff-v0.1.2-chrome.zip` with `data_collection_permissions` alongside the `background.scripts` fallback
- [ ] Manual: re-upload to Firefox AMO — validator should accept both fixes now
- [ ] Manual: same zip to Chrome Web Store (replaces in-review submission if any) and Edge Add-ons

🤖 Generated with [Claude Code](https://claude.com/claude-code)