### PR TITLE
feat(playground): BYOK web playground + landing-page embed

### DIFF
--- a/apps/outlook-addin/playground/index.html
+++ b/apps/outlook-addin/playground/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Try Defluff in your browser. Paste any email, bring your own API key — nothing is sent to a FinAegis server."
     />
+    <meta name="robots" content="noindex, nofollow" />
   </head>
   <body>
     <main>

--- a/apps/outlook-addin/playground/index.html
+++ b/apps/outlook-addin/playground/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defluff Playground — paste an email, get the point</title>
+    <meta
+      name="description"
+      content="Try Defluff in your browser. Paste any email, bring your own API key — nothing is sent to a FinAegis server."
+    />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Defluff Playground</h1>
+        <p class="lede" id="status">Loading…</p>
+      </header>
+
+      <section id="config" hidden>
+        <h2>Bring your own key</h2>
+        <p class="trust">
+          Your key and the text you paste stay in this browser. They go straight
+          to the provider you pick — never to a FinAegis server. Open your
+          browser's DevTools → Network tab and watch: the only request is to your
+          provider.
+          <a href="https://github.com/FinAegis/defluff" target="_blank" rel="noopener">Read the source.</a>
+        </p>
+
+        <label>
+          Provider
+          <select id="kind">
+            <option value="anthropic">Anthropic Claude</option>
+            <option value="openai">OpenAI</option>
+            <option value="gemini">Google Gemini</option>
+          </select>
+        </label>
+
+        <label>
+          API key
+          <input id="apikey" type="password" autocomplete="off" placeholder="paste your key" />
+        </label>
+
+        <label>
+          Model <small>(optional — leave blank for the provider default)</small>
+          <input id="model" type="text" placeholder="default model for the provider" />
+        </label>
+
+        <div class="actions">
+          <button id="save" type="button">Save key</button>
+          <button id="clear" type="button" class="secondary">Clear</button>
+          <span id="save-status" class="status-msg"></span>
+        </div>
+      </section>
+
+      <section id="work" hidden>
+        <label>
+          Paste an email
+          <textarea
+            id="input"
+            rows="12"
+            spellcheck="false"
+            placeholder="Paste the email body here…"
+          ></textarea>
+        </label>
+        <button id="run" type="button" class="primary">Defluff</button>
+        <div id="result" class="result" hidden>
+          <section id="prompt-block" class="prompt-block" hidden>
+            <p class="prompt-label">
+              <span aria-hidden="true" id="prompt-icon">💭</span>
+              <span id="prompt-label-text">Authorship</span>
+            </p>
+            <p class="prompt-text" id="prompt-text"></p>
+          </section>
+          <div id="verdict-row" class="verdict" hidden>
+            <span class="verdict-icon" id="verdict-icon" aria-hidden="true"></span>
+            <span class="verdict-label" id="verdict-label"></span>
+            <span class="verdict-reason" id="verdict-reason"></span>
+          </div>
+          <p class="section-label" id="bullets-label" hidden>Specifics</p>
+          <ul id="bullets"></ul>
+        </div>
+        <div id="error" class="error" hidden></div>
+        <p class="settings-link">
+          <button id="edit-config" type="button" class="link">Change provider or key…</button>
+        </p>
+      </section>
+    </main>
+    <script type="module" src="/src/playground/main.ts"></script>
+  </body>
+</html>

--- a/apps/outlook-addin/public/index.html
+++ b/apps/outlook-addin/public/index.html
@@ -301,6 +301,18 @@
     }
     section.band.alt { background: var(--panel); }
     section.band h2 { margin-bottom: 8px; }
+    .playground-embed {
+      width: 100%;
+      height: 720px;
+      margin-top: 24px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg);
+      box-shadow: var(--shadow);
+    }
+    @media (max-width: 600px) {
+      .playground-embed { height: 760px; }
+    }
     .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 28px; counter-reset: step; }
     .step {
       counter-increment: step;
@@ -550,6 +562,7 @@
         <span>Defluff</span>
       </a>
       <nav>
+        <a href="#try">Try it</a>
         <a href="#how">How it works</a>
         <a href="#surfaces">Works with</a>
         <a href="#privacy">Privacy</a>
@@ -607,9 +620,27 @@
     </div>
   </section>
 
+  <section id="try" class="band alt">
+    <div class="container">
+      <p class="section-overline"><span class="mark">§</span>01 · Try it now</p>
+      <h2>Try it in your browser</h2>
+      <p class="lede">
+        Paste an email, bring your own API key, see the bullets. The playground
+        calls your provider straight from this page — nothing reaches a FinAegis
+        server. <a href="playground/">Open the full playground ↗</a>
+      </p>
+      <iframe
+        class="playground-embed"
+        src="playground/"
+        title="Defluff playground — paste an email and extract its intent"
+        loading="lazy"
+      ></iframe>
+    </div>
+  </section>
+
   <section id="how" class="band">
     <div class="container">
-      <p class="section-overline"><span class="mark">§</span>01 · How it works</p>
+      <p class="section-overline"><span class="mark">§</span>02 · How it works</p>
       <h2>How it works</h2>
       <p class="lede">Three steps, about sixty seconds to set up. No account.</p>
       <div class="steps">
@@ -631,7 +662,7 @@
 
   <section id="surfaces" class="band alt">
     <div class="container">
-      <p class="section-overline"><span class="mark">§</span>02 · Where it works</p>
+      <p class="section-overline"><span class="mark">§</span>03 · Where it works</p>
       <h2>Where it works</h2>
       <p class="lede">Primary targets are Gmail and LinkedIn Messaging. Outlook Web is supported. The Office.js desktop add-in is available as a preview.</p>
       <ul class="rail">
@@ -673,7 +704,7 @@
 
   <section class="band">
     <div class="container">
-      <p class="section-overline"><span class="mark">§</span>03 · Agent surfaces</p>
+      <p class="section-overline"><span class="mark">§</span>04 · Agent surfaces</p>
       <div class="skill-callout">
         <h2>Living in an agent? There's a skill.</h2>
         <p>
@@ -694,7 +725,7 @@
 
   <section id="privacy" class="band alt">
     <div class="container">
-      <p class="section-overline"><span class="mark">§</span>04 · Privacy</p>
+      <p class="section-overline"><span class="mark">§</span>05 · Privacy</p>
       <h2>The privacy sell</h2>
       <p class="lede">
         Defluff has no backend. Your email content and your API key never leave your browser for infrastructure we run. Not a policy — the architecture.
@@ -762,7 +793,7 @@
 
   <section class="band">
     <div class="container">
-      <p class="section-overline"><span class="mark">§</span>05 · Proof points</p>
+      <p class="section-overline"><span class="mark">§</span>06 · Proof points</p>
       <h2>Proof points</h2>
       <ul class="manifesto">
         <li class="manifesto-item">

--- a/apps/outlook-addin/src/playground/main.ts
+++ b/apps/outlook-addin/src/playground/main.ts
@@ -1,0 +1,250 @@
+import {
+  AUTHORED_ICONS,
+  AUTHORED_LABELS,
+  AUTHORED_PROMPT_LABELS,
+  buildProviderConfig,
+  DefluffError,
+  formatReversedPrompt,
+  isProviderKind,
+  PROVIDER_DEFAULT_MODELS,
+  summarize,
+  toUserError,
+  VERDICT_ICONS,
+  VERDICT_LABELS,
+  type ProviderConfig,
+  type ProviderKind,
+  type Summary,
+} from '@defluff/core';
+import './styles.css';
+import {
+  clearProviderConfig,
+  getProviderConfig,
+  setProviderConfig,
+} from './storage.js';
+
+wireUi();
+syncModelPlaceholder();
+if (getProviderConfig()) {
+  showWork();
+} else {
+  showConfig();
+}
+
+function wireUi(): void {
+  byId<HTMLSelectElement>('kind').addEventListener('change', syncModelPlaceholder);
+  byId<HTMLButtonElement>('save').addEventListener('click', () => void handleSave());
+  byId<HTMLButtonElement>('clear').addEventListener('click', () => handleClear());
+  byId<HTMLButtonElement>('run').addEventListener('click', () => void handleRun());
+  byId<HTMLButtonElement>('edit-config').addEventListener('click', () => {
+    showConfig(getProviderConfig());
+  });
+}
+
+function showConfig(existing: ProviderConfig | null = getProviderConfig()): void {
+  byId('status').textContent = existing
+    ? 'Update your provider or key below.'
+    : 'Pick a provider and paste your own API key to begin.';
+  byId('config').hidden = false;
+  byId('work').hidden = true;
+
+  if (existing) {
+    byId<HTMLSelectElement>('kind').value = existing.kind;
+    if ('apiKey' in existing) byId<HTMLInputElement>('apikey').value = existing.apiKey ?? '';
+    if ('model' in existing && existing.model) {
+      byId<HTMLInputElement>('model').value = existing.model;
+    }
+  }
+  syncModelPlaceholder();
+}
+
+function showWork(): void {
+  byId('status').textContent = 'Paste an email below and click Defluff.';
+  byId('config').hidden = true;
+  byId('work').hidden = false;
+  byId('result').hidden = true;
+  byId('error').hidden = true;
+}
+
+function syncModelPlaceholder(): void {
+  byId<HTMLInputElement>('model').placeholder = PROVIDER_DEFAULT_MODELS[readKind()];
+}
+
+async function handleSave(): Promise<void> {
+  try {
+    const config = buildProviderConfig({
+      kind: readKind(),
+      apiKey: byId<HTMLInputElement>('apikey').value,
+      model: byId<HTMLInputElement>('model').value,
+      baseUrl: '',
+    });
+    setProviderConfig(config);
+    setSaveStatus('Saved', 'ok');
+    window.setTimeout(() => showWork(), 600);
+  } catch (err) {
+    setSaveStatus(err instanceof Error ? err.message : 'Failed to save', 'err');
+  }
+}
+
+function handleClear(): void {
+  clearProviderConfig();
+  byId<HTMLInputElement>('apikey').value = '';
+  byId<HTMLInputElement>('model').value = '';
+  setSaveStatus('Cleared', 'ok');
+}
+
+async function handleRun(): Promise<void> {
+  const config = getProviderConfig();
+  if (!config) {
+    showConfig(null);
+    return;
+  }
+
+  const runButton = byId<HTMLButtonElement>('run');
+  runButton.disabled = true;
+  runButton.textContent = 'Extracting…';
+  byId('result').hidden = true;
+  byId('error').hidden = true;
+
+  try {
+    const text = byId<HTMLTextAreaElement>('input').value.trim();
+    if (!text) throw new DefluffError('bad_request', 'Paste some text first.');
+    const summary = await summarize({ text, provider: config });
+    renderSummary(summary);
+  } catch (err) {
+    renderError(err);
+  } finally {
+    runButton.disabled = false;
+    runButton.textContent = 'Defluff';
+  }
+}
+
+function renderSummary(summary: Summary): void {
+  const result = byId('result');
+  result.dataset.verdict = summary.verdict ?? '';
+
+  const promptBlock = byId('prompt-block');
+  const promptIcon = byId<HTMLElement>('prompt-icon');
+  const promptLabel = byId<HTMLElement>('prompt-label-text');
+  const promptText = byId<HTMLElement>('prompt-text');
+  const authored = summary.authored;
+  if (authored) {
+    promptBlock.dataset.authored = authored;
+    promptIcon.textContent = AUTHORED_ICONS[authored];
+    promptLabel.textContent =
+      authored === 'human' ? AUTHORED_LABELS.human : AUTHORED_PROMPT_LABELS[authored];
+    if (authored === 'human') {
+      promptText.textContent = summary.authoredReason ?? '';
+      promptText.hidden = !summary.authoredReason;
+    } else {
+      promptText.textContent = summary.reversedPrompt
+        ? formatReversedPrompt(summary.reversedPrompt)
+        : '';
+      promptText.hidden = !summary.reversedPrompt;
+    }
+    promptBlock.hidden = false;
+  } else if (summary.reversedPrompt) {
+    // Legacy fallback: older models may omit Authored.
+    delete promptBlock.dataset.authored;
+    promptIcon.textContent = '💭';
+    promptLabel.textContent = 'They probably asked an AI';
+    promptText.textContent = formatReversedPrompt(summary.reversedPrompt);
+    promptText.hidden = false;
+    promptBlock.hidden = false;
+  } else {
+    promptBlock.hidden = true;
+  }
+
+  const verdictRow = byId('verdict-row');
+  if (summary.verdict) {
+    verdictRow.dataset.verdict = summary.verdict;
+    byId<HTMLElement>('verdict-icon').textContent = VERDICT_ICONS[summary.verdict];
+    byId<HTMLElement>('verdict-label').textContent = VERDICT_LABELS[summary.verdict];
+    byId<HTMLElement>('verdict-reason').textContent = summary.verdictReason ?? '';
+    verdictRow.hidden = false;
+  } else {
+    verdictRow.hidden = true;
+  }
+
+  const list = byId<HTMLUListElement>('bullets');
+  list.replaceChildren();
+  const bulletsLabel = byId('bullets-label');
+  if (summary.bullets.length > 0) {
+    for (const bullet of summary.bullets) {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    }
+    list.hidden = false;
+    bulletsLabel.hidden = false;
+  } else {
+    list.hidden = true;
+    bulletsLabel.hidden = true;
+  }
+
+  result.hidden = false;
+}
+
+function renderError(err: unknown): void {
+  const userError =
+    err instanceof DefluffError
+      ? toUserError(err.code, err.message)
+      : toUserError(undefined, err instanceof Error ? err.message : 'Unknown error');
+
+  const pane = byId('error');
+  pane.replaceChildren();
+
+  const heading = document.createElement('strong');
+  heading.textContent = userError.title;
+  pane.appendChild(heading);
+
+  if (userError.explanation) {
+    const p = document.createElement('p');
+    p.textContent = userError.explanation;
+    pane.appendChild(p);
+  }
+
+  if (userError.details) {
+    const disclosure = document.createElement('details');
+    disclosure.className = 'error-details';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Provider response';
+    disclosure.appendChild(summary);
+    const body = document.createElement('pre');
+    body.className = 'error-details-body';
+    body.textContent = userError.details;
+    disclosure.appendChild(body);
+    pane.appendChild(disclosure);
+  }
+
+  if (userError.action === 'configure') {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'secondary';
+    btn.textContent = 'Change provider';
+    btn.addEventListener('click', () => showConfig(getProviderConfig()));
+    pane.appendChild(btn);
+  }
+
+  pane.hidden = false;
+}
+
+function readKind(): ProviderKind {
+  const value = byId<HTMLSelectElement>('kind').value;
+  return isProviderKind(value) ? value : 'anthropic';
+}
+
+function setSaveStatus(text: string, variant: 'ok' | 'err'): void {
+  const el = byId('save-status');
+  el.textContent = text;
+  el.className = `status-msg ${variant}`;
+  window.setTimeout(() => {
+    el.textContent = '';
+    el.className = 'status-msg';
+  }, 2000);
+}
+
+function byId<T extends HTMLElement = HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Missing element: ${id}`);
+  return el as T;
+}

--- a/apps/outlook-addin/src/playground/storage.ts
+++ b/apps/outlook-addin/src/playground/storage.ts
@@ -1,0 +1,26 @@
+import { isProviderConfig, type ProviderConfig } from '@defluff/core';
+
+// The playground is a plain web page — no Office.js, no chrome.storage. The
+// user's provider config (including their API key) lives only in this
+// browser's localStorage and is sent only to the provider they pick.
+const STORAGE_KEY = 'defluff.playground.provider';
+
+/** Read the saved provider config. Returns null if unset or malformed. */
+export function getProviderConfig(): ProviderConfig | null {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isProviderConfig(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setProviderConfig(config: ProviderConfig): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+export function clearProviderConfig(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/apps/outlook-addin/src/playground/styles.css
+++ b/apps/outlook-addin/src/playground/styles.css
@@ -1,0 +1,228 @@
+:root {
+  --bg: #ffffff;
+  --fg: #202124;
+  --muted: #5f6368;
+  --border: #dadce0;
+  --accent: #1a73e8;
+  --accent-hover: #1558b0;
+  --ok: #188038;
+  --err: #d93025;
+  --panel: #f8faff;
+  --err-bg: #fce8e6;
+  --code-bg: #f1f3f4;
+  --verdict-actionable: #d93025;
+  --verdict-response: var(--accent);
+  --verdict-fyi: var(--muted);
+  --verdict-noise: #80868b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #202124;
+    --fg: #e8eaed;
+    --muted: #9aa0a6;
+    --border: #3c4043;
+    --accent: #8ab4f8;
+    --accent-hover: #aecbfa;
+    --ok: #81c995;
+    --err: #f28b82;
+    --panel: #2a2d31;
+    --err-bg: #3a1e21;
+    --code-bg: #2a2d31;
+    --verdict-actionable: #f28b82;
+    --verdict-noise: #6b6e73;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+main { max-width: 640px; margin: 0 auto; padding: 32px 24px 56px; }
+
+header h1 { margin: 0 0 6px; font-size: 22px; font-weight: 600; }
+.lede { color: var(--muted); margin: 0 0 24px; }
+
+section { display: flex; flex-direction: column; gap: 14px; }
+
+.trust {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.trust a { color: var(--accent); }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+}
+label small { font-weight: 400; color: var(--muted); }
+
+input, select, textarea {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+  background: var(--bg);
+  color: var(--fg);
+}
+textarea { resize: vertical; }
+input:focus, select:focus, textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
+}
+
+.actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+button {
+  padding: 10px 20px;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+}
+button:hover { background: var(--accent-hover); }
+button:disabled { opacity: 0.6; cursor: not-allowed; }
+button.secondary {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+button.secondary:hover { background: var(--panel); }
+button.primary { width: 100%; padding: 12px; font-size: 15px; }
+button.link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+button.link:hover { text-decoration: underline; }
+
+.status-msg { font-weight: 500; font-size: 13px; }
+.status-msg.ok { color: var(--ok); }
+.status-msg.err { color: var(--err); }
+
+.result {
+  padding: 14px 16px;
+  background: var(--panel);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+}
+.result[data-verdict="noise"] ul { opacity: 0.65; }
+
+.prompt-block {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-left: 2px solid var(--accent);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.prompt-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.prompt-text { margin: 0; font-style: italic; font-size: 13px; color: var(--fg); }
+.prompt-block[data-authored="human"] {
+  background: transparent;
+  border-left-color: transparent;
+  padding: 0 0 4px;
+}
+.prompt-block[data-authored="human"] .prompt-text {
+  font-style: normal;
+  color: var(--muted);
+}
+
+.verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+.verdict[data-verdict="actionable"] { color: var(--verdict-actionable); }
+.verdict[data-verdict="response-needed"] { color: var(--verdict-response); }
+.verdict[data-verdict="fyi"] { color: var(--verdict-fyi); }
+.verdict[data-verdict="noise"] { color: var(--verdict-noise); }
+.verdict-label {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.verdict-reason { color: var(--fg); font-style: italic; font-weight: 400; }
+
+.section-label {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.result ul { margin: 0; padding-left: 20px; }
+.result li { margin-bottom: 4px; }
+
+.error {
+  padding: 14px 16px;
+  background: var(--err-bg);
+  border-left: 3px solid var(--err);
+  color: var(--fg);
+  font-size: 13px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.error strong { color: var(--err); font-size: 14px; }
+.error p { margin: 0; }
+.error button { align-self: flex-start; margin-top: 4px; }
+
+.error-details { font-size: 12px; }
+.error-details summary { cursor: pointer; color: var(--muted); }
+.error-details-body {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+}
+
+.settings-link { margin: 4px 0 0; font-size: 13px; color: var(--muted); }

--- a/apps/outlook-addin/vite.config.ts
+++ b/apps/outlook-addin/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ command }) => ({
       input: {
         taskpane: resolve(__dirname, 'src/taskpane/index.html'),
         commands: resolve(__dirname, 'src/commands/commands.html'),
+        playground: resolve(__dirname, 'playground/index.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
Adds a standalone web playground so anyone with an API key can defluff pasted text without installing the extension — and embeds it on the landing page.

- New `/defluff/playground/` page (plain TS, mirrors the Outlook task pane). Provider config + key in `localStorage`; `summarize()` runs provider-direct from the browser (Anthropic / OpenAI / Gemini).
- One-line addition to the existing `apps/outlook-addin` Vite build — no new app, no new CI.
- Landing page gains an interactive "Try it" section (iframe to `/playground/`) + nav link; existing section overlines renumbered to keep §01–§06 sequential.
- `noindex, nofollow` added to playground HTML to prevent duplicate SEO signal against the landing page.

Part 2 of 2 (Part 1 was the extension popup, #44).

Spec: `docs/superpowers/specs/2026-05-22-paste-defluff-design.md`
Plan: `docs/superpowers/plans/2026-05-22-paste-defluff.md`

## Test plan
- `pnpm --filter @defluff/outlook-addin typecheck` / `build` pass; `dist/playground/index.html` produced with hashed assets.
- Built landing page: `grep id=\"try\" dist/index.html` matches; all six §0N overlines present in order.
- Manual: open `/playground/` directly, save a key, paste an email, click Defluff → result card; DevTools Network shows only the provider request (CORS verified per provider used).

## Post-phase review
Clean pass. No Critical or Important findings. Minor fix applied: added `<meta name="robots" content="noindex, nofollow">` to playground page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)