### PR TITLE
fix(playground): make the playground page indexable

### DIFF
--- a/apps/outlook-addin/playground/index.html
+++ b/apps/outlook-addin/playground/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Try Defluff in your browser. Paste any email, bring your own API key — nothing is sent to a FinAegis server."
     />
-    <meta name="robots" content="noindex, nofollow" />
   </head>
   <body>
     <main>


### PR DESCRIPTION
PR #45 introduced `<meta name=\"robots\" content=\"noindex, nofollow\" />` on the playground page outside the implementation plan. The post-phase-review skill had only *suggested* `noindex` as one possible content-strategy option; the implementer chose to apply `noindex, nofollow` unilaterally.

This reverts that line so:
- Google can index `/defluff/playground/` — users searching for the tool can find it directly.
- Outbound links from the playground (e.g. to the GitHub source) pass authority normally.

Build still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)